### PR TITLE
docs: add CLAUDE.md, exercise dynamixel sync/bulk in motor_controller

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# Working in this repo
+
+Zephyr workspace driven by `uv` (Python env) + `poethepoet` (task runner) + `west` (Zephyr meta-tool). Read this before running anything.
+
+## Python environment: always `uv run`
+
+Every Python tool — including `west` — must be invoked through `uv run`. The repo's venv lives at `.venv/` but you never activate it.
+
+```bash
+uv run west <args>          # west calls
+uv run poe <task> [args]    # poe tasks (preferred)
+uv run python <script>      # ad-hoc python
+```
+
+Forbidden:
+
+- `source .venv/bin/activate` — don't activate, don't suggest activating.
+- Bare `west`, `python`, `pip`, `pytest`. They will hit the wrong interpreter or fail entirely.
+- `pip install …` — dependencies are pinned in `pyproject.toml`; use `uv sync` if something is missing and check it in.
+
+If a command needs a sub-shell or background invocation, prefix the inner command with `uv run` too (e.g. `nohup uv run west build … &`).
+
+## Build apps via `poe`, not bare `west build`
+
+Per-app build dirs live at `builds/<app>/`. The `poe` tasks already encode the right board, build dir, and flags. Use them.
+
+```bash
+uv run poe build-motor          # motor_controller
+uv run poe build-vision         # embedded_vision
+uv run poe build-force          # force_sensor
+uv run poe build-joystick       # joystick_controller
+uv run poe build-rasprover      # rasprover (sysbuild + MCUboot)
+uv run poe sim-rasprover        # rasprover native_sim
+uv run poe build <app-path>     # generic; needs MY_BOARD in .env or env
+uv run poe flash <app-path>     # flash a previously built app
+```
+
+For agent-driven builds where you want truncated logs (and a full log on disk), use `agent-build`:
+
+```bash
+uv run poe agent-build applications/motor_controller
+# → builds with -p always, writes logs/motor_controller-build.log,
+#   prints last 5 lines on success, last 50 on failure.
+# Override with TAIL_S / TAIL_F.
+```
+
+If you must call `west build` directly, always pass `--build-dir builds/<app>` so artifacts don't pollute the repo root.
+
+`pico_fw` is the exception: it has its own west workspace under `applications/pico_fw/` due to a cyw43 module conflict. Build it from there.
+
+## Workspace updates
+
+```bash
+uv run poe setup            # first-time: west update + SDK install + blobs + zenoh patch
+uv run poe west-update      # refresh deps/ after pulling new manifest revisions
+uv run poe sdk-install      # reinstall SDK toolchains (version pinned in deps/zephyr/SDK_VERSION)
+```
+
+The west.yml uses `name-allowlist` to clone only the modules these apps need; do not remove modules from that list to "fix" missing-symbol errors without checking what depends on them.
+
+## Layout
+
+- `applications/<app>/` — Zephyr apps (`prj.conf`, `CMakeLists.txt`, `src/`, optional `boards/<board>.overlay`).
+- `boards/<vendor>/<board>/` — out-of-tree board definitions.
+- `dts/bindings/` — out-of-tree DT bindings.
+- `deps/zephyr/` — Zephyr tree (managed by west, gitignored).
+- `deps/modules/lib/rosterloh-drivers/` — out-of-tree drivers repo. Tracks `main` via west.yml. Local edits during PR development are fine; commit them in that repo, not this one.
+- `deps/modules/lib/zenoh/` — zenoh-pico, patched by `poe patch-zenoh`.
+- `builds/<app>/` — build outputs (gitignored).
+- `logs/` — `agent-build` log destination.
+- `.env` — selects `MY_BOARD` for the generic `build` task.
+
+## Formatting
+
+- Python: `uv run poe fmt` (ruff format, line-length 120).
+- C / Zephyr code: clang-format using the in-tree `.clang-format`. Verify with `uv run clang-format --dry-run --Werror <files>`.
+
+## Out-of-tree modules and PR work
+
+When iterating on `deps/modules/lib/rosterloh-drivers` (or zenoh) you are editing a real git checkout. Standard flow:
+
+1. Branch and commit inside the module dir.
+2. Push and open a PR against that module's repo (e.g. `rosterloh/zephyr-drivers`).
+3. Verify dependent apps still build from this workspace: `uv run poe build-motor`, etc.
+4. After merge: `uv run poe west-update` to advance the pinned `main` ref locally.
+
+Do **not** vendor module changes into this repo; west owns those paths.
+
+## Don'ts
+
+- Don't `cd deps/zephyr` to run west commands — run them from the workspace root.
+- Don't create a top-level `build/` directory; always pass `--build-dir builds/<app>`.
+- Don't commit `.venv/`, `builds/`, `deps/`, or `logs/` (already gitignored).
+- Don't add a `requirements.txt` or `Pipfile`; deps go in `pyproject.toml` and are locked by `uv`.

--- a/applications/motor_controller/src/main.c
+++ b/applications/motor_controller/src/main.c
@@ -12,6 +12,8 @@ LOG_MODULE_REGISTER(main, CONFIG_APP_LOG_LEVEL);
 #define NEOSLIDER_NEOPIN   14
 #define NEOSLIDER_ANALOGIN 18
 #define DXL_DEV_NAME       DEVICE_DT_NAME(DT_INST(0, robotis_dynamixel))
+#define MAX_MOTORS         8
+#define TELEMETRY_PERIOD   K_MSEC(1000)
 
 static int iface;
 const static struct dxl_iface_param dxl_param = {
@@ -22,10 +24,12 @@ const static struct dxl_iface_param dxl_param = {
 			.parity = UART_CFG_PARITY_NONE,
 		},
 };
-static uint8_t motor_id = 1;
+static uint8_t motor_ids[MAX_MOTORS];
+static size_t motor_count;
 static const struct device *const neoslider = DEVICE_DT_GET(DT_NODELABEL(neoslider));
 static uint16_t last_slider = 0;
 struct k_work_delayable inputs_scan_work;
+struct k_work_delayable telemetry_work;
 char slide_str[11] = {0};
 static lv_obj_t *slide_label;
 static lv_obj_t *slider;
@@ -43,14 +47,84 @@ static void inputs_scan_fn(struct k_work *work)
 			lv_label_set_text(slide_label, slide_str);
 			last_slider = slide_val;
 
-			err = dxl_write_u32(iface, motor_id, GOAL_POSITION, slide_val * 4);
-			if (err != 0) {
-				LOG_ERR("Failed to write goal position. %d", err);
+			if (motor_count > 0) {
+				/* SYNC_WRITE: broadcast the same GOAL_POSITION to every
+				 * motor on the bus in a single transaction. */
+				uint32_t goals[MAX_MOTORS];
+
+				for (size_t i = 0; i < motor_count; i++) {
+					goals[i] = (uint32_t)slide_val * 4;
+				}
+				err = dxl_sync_write_u32(iface, GOAL_POSITION, motor_ids,
+							 goals, motor_count);
+				if (err != 0) {
+					LOG_ERR("sync_write GOAL_POSITION failed. %d", err);
+				}
 			}
 		}
 	}
 
 	k_work_reschedule(&inputs_scan_work, K_MSEC(300));
+}
+
+static void telemetry_fn(struct k_work *work)
+{
+	int err;
+
+	if (motor_count == 0) {
+		goto reschedule;
+	}
+
+	/* SYNC_READ: pull PRESENT_POSITION from every motor in one transaction. */
+	uint32_t positions[MAX_MOTORS];
+	int sync_errs[MAX_MOTORS];
+
+	err = dxl_sync_read_u32(iface, PRESENT_POSITION, motor_ids, positions, sync_errs,
+				motor_count);
+	if (err == 0) {
+		for (size_t i = 0; i < motor_count; i++) {
+			LOG_INF("motor %u position=%u", motor_ids[i], positions[i]);
+		}
+	} else {
+		LOG_WRN("sync_read PRESENT_POSITION rc=%d", err);
+		for (size_t i = 0; i < motor_count; i++) {
+			if (sync_errs[i] != 0) {
+				LOG_WRN("  motor %u err=%d", motor_ids[i], sync_errs[i]);
+			}
+		}
+	}
+
+	/* BULK_READ: query a different register per entry in one transaction.
+	 * Here we ask each motor for both its temperature and hardware error
+	 * status — useful as a periodic health check. */
+	struct dxl_bulk_read_entry req[MAX_MOTORS * 2];
+	uint32_t bulk_vals[MAX_MOTORS * 2];
+	int bulk_errs[MAX_MOTORS * 2];
+	size_t n = 0;
+
+	for (size_t i = 0; i < motor_count && n + 1 < ARRAY_SIZE(req); i++) {
+		req[n++] = (struct dxl_bulk_read_entry){
+			.id = motor_ids[i],
+			.item = PRESENT_TEMPERATURE,
+		};
+		req[n++] = (struct dxl_bulk_read_entry){
+			.id = motor_ids[i],
+			.item = HARDWARE_ERROR_STATUS,
+		};
+	}
+
+	err = dxl_bulk_read(iface, req, bulk_vals, bulk_errs, n);
+	if (err == 0) {
+		for (size_t i = 0; i < n; i++) {
+			LOG_INF("motor %u item=%d val=%u", req[i].id, req[i].item,
+				bulk_vals[i]);
+		}
+	} else {
+		LOG_WRN("bulk_read rc=%d", err);
+	}
+
+reschedule:
+	k_work_reschedule(&telemetry_work, TELEMETRY_PERIOD);
 }
 
 int main(void)
@@ -72,16 +146,64 @@ int main(void)
 		return -ENODEV;
 	}
 
-	ret = dxl_ping(iface, motor_id);
-	if (ret == 0) {
-		ret = dxl_write_u8(iface, motor_id, TORQUE_ENABLE, 0);
-		ret |= dxl_write_u8(iface, motor_id, OPERATING_MODE, DXL_OP_POSITION);
-		ret |= dxl_write_u8(iface, motor_id, TORQUE_ENABLE, 1);
-		if (ret != 0) {
-			LOG_ERR("Failed to configure motor. %d", ret);
+	/* Discover motors from devicetree and ping each one. */
+	const size_t total = dxl_motor_count();
+
+	for (size_t i = 0; i < total && motor_count < MAX_MOTORS; i++) {
+		const struct dxl_motor *m = dxl_motor_get(i);
+
+		if (m == NULL || m->iface != iface) {
+			continue;
 		}
-	} else {
-		LOG_WRN("Failed to ping motor with ID %d", motor_id);
+		if (dxl_ping(iface, m->id) != 0) {
+			LOG_WRN("Motor '%s' (id=%u) did not respond to ping",
+				m->label ? m->label : "?", m->id);
+			continue;
+		}
+		motor_ids[motor_count++] = m->id;
+	}
+	LOG_INF("Discovered %u dynamixel motor(s)", (unsigned)motor_count);
+
+	if (motor_count > 0) {
+		/* SYNC_WRITE: push TORQUE_ENABLE / OPERATING_MODE / TORQUE_ENABLE
+		 * to every motor in three broadcast bursts instead of N*3 unicasts. */
+		uint8_t off[MAX_MOTORS] = {0};
+		uint8_t mode[MAX_MOTORS];
+		uint8_t on[MAX_MOTORS];
+
+		for (size_t i = 0; i < motor_count; i++) {
+			mode[i] = DXL_OP_POSITION;
+			on[i] = 1;
+		}
+
+		ret = dxl_sync_write_u8(iface, TORQUE_ENABLE, motor_ids, off, motor_count);
+		ret |= dxl_sync_write_u8(iface, OPERATING_MODE, motor_ids, mode, motor_count);
+		ret |= dxl_sync_write_u8(iface, TORQUE_ENABLE, motor_ids, on, motor_count);
+		if (ret != 0) {
+			LOG_ERR("Failed to configure motors. %d", ret);
+		}
+
+		/* BULK_WRITE: set PROFILE_VELOCITY and LED on each motor in one
+		 * transaction, mixing two different registers per motor. */
+		struct dxl_bulk_write_entry init_writes[MAX_MOTORS * 2];
+		size_t n = 0;
+
+		for (size_t i = 0; i < motor_count && n + 1 < ARRAY_SIZE(init_writes); i++) {
+			init_writes[n++] = (struct dxl_bulk_write_entry){
+				.id = motor_ids[i],
+				.item = PROFILE_VELOCITY,
+				.value = 100,
+			};
+			init_writes[n++] = (struct dxl_bulk_write_entry){
+				.id = motor_ids[i],
+				.item = LED,
+				.value = 1,
+			};
+		}
+		ret = dxl_bulk_write(iface, init_writes, n);
+		if (ret != 0) {
+			LOG_ERR("bulk_write init failed. %d", ret);
+		}
 	}
 
 	if (!device_is_ready(neoslider)) {
@@ -98,6 +220,8 @@ int main(void)
 
 	k_work_init_delayable(&inputs_scan_work, inputs_scan_fn);
 	k_work_reschedule(&inputs_scan_work, K_NO_WAIT);
+	k_work_init_delayable(&telemetry_work, telemetry_fn);
+	k_work_reschedule(&telemetry_work, TELEMETRY_PERIOD);
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
   "west>=1.5.0",
   "windows-curses>=2.4.2 ; sys_platform == 'win32'",
   "yamllint>=1.37.1",
-  "zephyr-kconfig>=0.2.0",
+  "zephyr-kconfig>=0.2.1",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -2043,7 +2043,7 @@ dev = [
     { name = "west", specifier = ">=1.5.0" },
     { name = "windows-curses", marker = "sys_platform == 'win32'", specifier = ">=2.4.2" },
     { name = "yamllint", specifier = ">=1.37.1" },
-    { name = "zephyr-kconfig", specifier = ">=0.2.0" },
+    { name = "zephyr-kconfig", specifier = ">=0.2.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — project rules for working in this repo. Codifies the `uv` + `poethepoet` + `west` workflow (always `uv run`, prefer `poe build-*` tasks, `agent-build` for log-truncated runs), repo layout, out-of-tree module flow for `rosterloh-drivers` / `zenoh`, and a don'ts list. Lands so future agent sessions don't need to be reminded to use the venv.
- **motor_controller**: exercises the new SYNC/BULK group instructions that landed in rosterloh/zephyr-drivers#8.
  - Discovers motors from devicetree via `dxl_motor_get()` / `dxl_motor_count()` and pings each.
  - Configures every motor in one go: 3× `dxl_sync_write_u8` (TORQUE_ENABLE / OPERATING_MODE / TORQUE_ENABLE) + a `dxl_bulk_write` setting PROFILE_VELOCITY and LED per motor in a single transaction.
  - Slider work-handler now broadcasts GOAL_POSITION via `dxl_sync_write_u32`.
  - New 1 Hz telemetry handler reads PRESENT_POSITION via `dxl_sync_read_u32` and PRESENT_TEMPERATURE + HARDWARE_ERROR_STATUS via `dxl_bulk_read`.

The current overlay declares one motor (`id=1`, "TEST"); the code scales as more child nodes are added.

## Test plan

- [x] \`uv run poe build-motor\` — builds clean (601/601, FLASH 93.91% / RAM 96.09%) against merged \`rosterloh-drivers/main\` (\`0ffd91d\`)
- [x] No new warnings on \`main.c\`
- [ ] Manual: flash to \`robotis_openrb_150\` and verify slider drives the servo and telemetry logs as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)