### PR TITLE
rasprover: publish wheel joint states

### DIFF
--- a/applications/rasprover/CHANGELOG.md
+++ b/applications/rasprover/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actuator subsystem, with quadrature PCNT encoder feedback.
 - Zenoh `cmd_vel` subscriber (CDR `geometry_msgs/Twist`) with a
   stop-on-silence watchdog.
+- Zenoh `/joint_states` publisher (CDR `sensor_msgs/JointState`) from wheel
+  actuator feedback.
+- SNTP time synchronization for ROS header timestamps, with zero timestamps
+  used until the first successful sync.
 
 ## [v1.0.0] - 2024-xx-xx
 

--- a/applications/rasprover/CMakeLists.txt
+++ b/applications/rasprover/CMakeLists.txt
@@ -18,6 +18,8 @@ target_sources_ifdef(CONFIG_APP_DISPLAY app PRIVATE src/app_display.c)
 target_sources_ifdef(CONFIG_NETWORKING app PRIVATE src/app_network.c)
 target_sources_ifdef(CONFIG_APP_ZENOH  app PRIVATE src/app_zenoh.c)
 target_sources_ifdef(CONFIG_APP_MOTORS app PRIVATE src/app_motors.c)
+target_sources_ifdef(CONFIG_APP_TIME_SYNC app PRIVATE src/app_time.c)
+target_sources(app PRIVATE src/app_ros_cdr.c)
 
 # On Debian/Ubuntu, libsdl2-dev uses a multiarch include path that Zephyr's
 # build doesn't pick up automatically. Add it via pkg-config when present.

--- a/applications/rasprover/Kconfig
+++ b/applications/rasprover/Kconfig
@@ -80,10 +80,11 @@ config APP_ZENOH_KEY_PREFIX
 	string "Zenoh key expression prefix for all published topics"
 	default "rt/rasprover"
 	help
-	  Key prefix for all zenoh publishers. The 'rt/' convention is required
-	  by the zenoh-ros2dds bridge to route topics into ROS2. The full key
-	  for the battery state topic will be <prefix>/battery_state, which
-	  maps to the ROS2 topic /<prefix_without_rt>/battery_state.
+	  Key prefix for Rasprover-local zenoh publishers and subscribers. The
+	  'rt/' convention is required by the zenoh-ros2dds bridge to route
+	  topics into ROS2. The full key for the battery state topic will be
+	  <prefix>/battery_state, which maps to the ROS2 topic
+	  /<prefix_without_rt>/battery_state.
 
 # Numeric tunables consumed by the generated zenoh-pico/config.h (see
 # poe.toml: patch-zenoh). Defaults match the upstream zenoh-pico root
@@ -124,7 +125,56 @@ config APP_ZENOH_TRANSPORT_CONNECT_TIMEOUT_MS
 	int "Zenoh: P2P link connect timeout (ms)"
 	default 10000
 
+config APP_ZENOH_JOINT_STATE_KEY
+	string "Zenoh key expression for JointState"
+	default "rt/joint_states"
+	depends on APP_MOTORS
+	help
+	  Zenoh key used for sensor_msgs/JointState. The default maps through
+	  zenoh-ros2dds to the conventional ROS2 /joint_states topic.
+
+config APP_ZENOH_JOINT_STATE_PUBLISH_HZ
+	int "JointState publish rate in Hz"
+	default 20
+	range 1 100
+	depends on APP_MOTORS
+
 endif # APP_ZENOH
+
+menuconfig APP_TIME_SYNC
+	bool "Enable SNTP time synchronization"
+	default y if APP_ZENOH && NETWORKING
+	depends on NETWORKING
+	depends on NET_SOCKETS
+	depends on DNS_RESOLVER
+	select SNTP
+	select NET_SOCKETS_SERVICE
+	help
+	  Synchronize SYS_CLOCK_REALTIME from an SNTP server. Publishers that
+	  need ROS timestamps can publish immediately with a zero stamp and
+	  switch to realtime stamps after the first successful sync.
+
+if APP_TIME_SYNC
+
+config APP_TIME_SNTP_SERVER
+	string "SNTP server"
+	default "pool.ntp.org"
+
+config APP_TIME_SNTP_TIMEOUT_MS
+	int "SNTP query timeout in milliseconds"
+	default 3000
+
+config APP_TIME_SNTP_RETRY_SEC
+	int "SNTP retry interval after failure, in seconds"
+	default 15
+	range 1 3600
+
+config APP_TIME_SNTP_RESYNC_SEC
+	int "SNTP resync interval after success, in seconds"
+	default 3600
+	range 60 86400
+
+endif # APP_TIME_SYNC
 
 menuconfig APP_MOTORS
 	bool "Enable differential drive motor control"

--- a/applications/rasprover/README.md
+++ b/applications/rasprover/README.md
@@ -107,11 +107,18 @@ uv run west build -b ros_driver/esp32/procpu -p always --sysbuild \
   -- -DEXTRA_CONF_FILE=debug.conf
 ```
 
-## zenoh-pico sensor publishing
+## zenoh-pico ROS publishing
 
-The firmware publishes INA219 readings to a zenoh router on the host over **WiFi/TCP**. Messages are CDR-encoded `sensor_msgs/msg/BatteryState`, making them directly consumable by the [zenoh-ros2dds bridge](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds) with no conversion step.
+The firmware publishes INA219 readings and wheel feedback to a zenoh router on the host over **WiFi/TCP**. Messages are CDR-encoded ROS 2 messages, making them directly consumable by the [zenoh-ros2dds bridge](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds) with no conversion step.
 
-The zenoh key follows the `rt/<topic>` convention the bridge uses for ROS2 topics. With the default prefix the key is `rt/rasprover/battery_state`, which appears in ROS2 as `/rasprover/battery_state`.
+The zenoh key follows the `rt/<topic>` convention the bridge uses for ROS2 topics. With the default prefix the firmware publishes:
+
+| Zenoh key | ROS 2 topic | Message |
+|-----------|-------------|---------|
+| `rt/rasprover/battery_state` | `/rasprover/battery_state` | `sensor_msgs/msg/BatteryState` |
+| `rt/joint_states` | `/joint_states` | `sensor_msgs/msg/JointState` |
+
+Message headers publish immediately with a zero timestamp until SNTP sets `SYS_CLOCK_REALTIME`; after sync, header stamps use realtime.
 
 > Why TCP rather than serial? The upstream `zenoh-pico` west-module Zephyr integration unconditionally accesses `sock->_fd`, a struct field that only exists when at least one socket-based transport is enabled. A serial-only build doesn't compile. See `poe patch-zenoh` for the workspace patches that paper over this.
 
@@ -136,11 +143,12 @@ zenohd -l tcp/0.0.0.0:7447
 # 2. Launch the zenoh-ros2dds bridge on the host ROS2 machine
 ros2 launch zenoh_bridge_ros2dds zenoh_bridge_ros2dds.launch.py
 
-# 3. The topic is now visible in ROS2
+# 3. The topics are now visible in ROS2
 ros2 topic echo /rasprover/battery_state sensor_msgs/msg/BatteryState
+ros2 topic echo /joint_states sensor_msgs/msg/JointState
 ```
 
-Fields populated in each message:
+Fields populated in each BatteryState message:
 
 | Field | Source |
 |-------|--------|
@@ -151,13 +159,28 @@ Fields populated in each message:
 | `present` | `true` |
 | all others | `NaN` / 0 / empty |
 
+Fields populated in each JointState message:
+
+| Field | Source |
+|-------|--------|
+| `name` | `left_wheel_joint`, `right_wheel_joint` |
+| `position` | actuator feedback position (rad) |
+| `velocity` | actuator feedback velocity (rad/s), or 0 before velocity feedback is valid |
+| `effort` | empty |
+
 ### Configuration
 
 | Kconfig | Default | Description |
 |---------|---------|-------------|
 | `APP_ZENOH` | y | Enable the zenoh publisher |
 | `APP_ZENOH_LOCATOR` | `tcp/192.168.1.10:7447` | Locator passed to `z_open()`. Format `<protocol>/<host>:<port>`. |
-| `APP_ZENOH_KEY_PREFIX` | `rt/rasprover` | Key prefix — `rt/` routes topics through the zenoh-ros2dds bridge |
+| `APP_ZENOH_KEY_PREFIX` | `rt/rasprover` | Key prefix for Rasprover-local topics; `rt/` routes topics through the zenoh-ros2dds bridge |
+| `APP_ZENOH_JOINT_STATE_KEY` | `rt/joint_states` | JointState key, mapped to ROS 2 `/joint_states` by default |
+| `APP_ZENOH_JOINT_STATE_PUBLISH_HZ` | `20` | JointState publish rate |
+| `APP_TIME_SYNC` | y | Enable SNTP synchronization for ROS header timestamps |
+| `APP_TIME_SNTP_SERVER` | `pool.ntp.org` | SNTP server used for realtime clock sync |
+| `APP_TIME_SNTP_RETRY_SEC` | `15` | Retry interval after a failed SNTP sync |
+| `APP_TIME_SNTP_RESYNC_SEC` | `3600` | Resync interval after a successful SNTP sync |
 
 #### Advanced tunables
 

--- a/applications/rasprover/prj.conf
+++ b/applications/rasprover/prj.conf
@@ -45,6 +45,7 @@ CONFIG_POSIX_API=y
 CONFIG_NET_SOCKETS=y
 CONFIG_NET_TCP=y
 CONFIG_DNS_RESOLVER=y
+CONFIG_APP_TIME_SYNC=y
 # zenoh-pico uses malloc (libc heap), not k_heap; keep k_heap just for BT/MCUmgr
 CONFIG_HEAP_MEM_POOL_SIZE=4096
 

--- a/applications/rasprover/src/app_motors.c
+++ b/applications/rasprover/src/app_motors.c
@@ -12,6 +12,23 @@ static const struct device *const right_motor = DEVICE_DT_GET(DT_ALIAS(right_mot
 static struct k_work_delayable cmd_watchdog;
 static bool ready;
 
+static bool read_joint(const struct device *motor, const char *name,
+		       struct app_motors_joint_state *joint)
+{
+	struct actuator_feedback fb;
+
+	if (actuator_read_feedback(motor, &fb) != 0 || !(fb.valid_mask & ACTUATOR_FB_POSITION)) {
+		return false;
+	}
+
+	*joint = (struct app_motors_joint_state){
+		.name = name,
+		.position_rad = fb.position,
+		.velocity_rad_s = (fb.valid_mask & ACTUATOR_FB_VELOCITY) ? fb.velocity : 0.0,
+	};
+	return true;
+}
+
 static void cmd_watchdog_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
@@ -63,4 +80,14 @@ void app_motors_cmd_vel(float linear_x, float angular_z)
 	(void)actuator_set_velocity(right_motor, CLAMP(v_right / max_speed_m_s, -1.0f, 1.0f));
 
 	k_work_reschedule(&cmd_watchdog, K_MSEC(CONFIG_APP_MOTORS_CMD_TIMEOUT_MS));
+}
+
+bool app_motors_read_joint_state(struct app_motors_joint_state joints[APP_MOTORS_JOINT_COUNT])
+{
+	if (!ready || joints == NULL) {
+		return false;
+	}
+
+	return read_joint(left_motor, "left_wheel_joint", &joints[0]) &&
+	       read_joint(right_motor, "right_wheel_joint", &joints[1]);
 }

--- a/applications/rasprover/src/app_motors.h
+++ b/applications/rasprover/src/app_motors.h
@@ -3,9 +3,19 @@
 
 #include <stdbool.h>
 
+#define APP_MOTORS_JOINT_COUNT 2
+
+struct app_motors_joint_state {
+	const char *name;
+	double position_rad;
+	double velocity_rad_s;
+};
+
 bool app_motors_init(void);
 
 /* Differential-drive a geometry_msgs/Twist: linear.x (m/s), angular.z (rad/s). */
 void app_motors_cmd_vel(float linear_x, float angular_z);
+
+bool app_motors_read_joint_state(struct app_motors_joint_state joints[APP_MOTORS_JOINT_COUNT]);
 
 #endif /* __APP_MOTORS_H__ */

--- a/applications/rasprover/src/app_network.c
+++ b/applications/rasprover/src/app_network.c
@@ -558,3 +558,8 @@ void app_net_connect(void)
 	LOG_INF("Waiting to obtain IP address");
 	wait_for_net_event(iface, NET_EVENT_IPV4_ADDR_ADD);
 }
+
+bool app_net_ipv4_ready(void)
+{
+	return (atomic_get(&wifi_manager_data.net_state) & NET_STATE_IPV4_READY) != 0;
+}

--- a/applications/rasprover/src/app_network.h
+++ b/applications/rasprover/src/app_network.h
@@ -5,9 +5,15 @@
 
 #if IS_ENABLED(CONFIG_NETWORKING)
 void app_net_connect(void);
+bool app_net_ipv4_ready(void);
 #else
 static inline void app_net_connect(void)
 {
+}
+
+static inline bool app_net_ipv4_ready(void)
+{
+	return false;
 }
 #endif
 

--- a/applications/rasprover/src/app_ros_cdr.c
+++ b/applications/rasprover/src/app_ros_cdr.c
@@ -1,0 +1,172 @@
+#include "app_ros_cdr.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#define CDR_HEADER_SIZE 4
+#define F32_QNAN_LE     0x7FC00000u
+
+struct cdr_writer {
+	uint8_t *buf;
+	size_t len;
+	size_t cap;
+	bool ok;
+};
+
+static size_t cdr_rel(const struct cdr_writer *w)
+{
+	return (w->len >= CDR_HEADER_SIZE) ? (w->len - CDR_HEADER_SIZE) : 0;
+}
+
+static void cdr_reserve(struct cdr_writer *w, size_t len)
+{
+	if (w->len + len > w->cap) {
+		w->ok = false;
+	}
+}
+
+static void cdr_write_zeroes(struct cdr_writer *w, size_t len)
+{
+	cdr_reserve(w, len);
+	if (!w->ok) {
+		return;
+	}
+	memset(w->buf + w->len, 0, len);
+	w->len += len;
+}
+
+static void cdr_align(struct cdr_writer *w, size_t alignment)
+{
+	size_t rem = cdr_rel(w) % alignment;
+
+	if (rem != 0) {
+		cdr_write_zeroes(w, alignment - rem);
+	}
+}
+
+static void cdr_write_bytes(struct cdr_writer *w, const void *src, size_t len)
+{
+	cdr_reserve(w, len);
+	if (!w->ok) {
+		return;
+	}
+	memcpy(w->buf + w->len, src, len);
+	w->len += len;
+}
+
+static void cdr_write_u32(struct cdr_writer *w, uint32_t v)
+{
+	uint8_t bytes[4] = {
+		(uint8_t)v,
+		(uint8_t)(v >> 8),
+		(uint8_t)(v >> 16),
+		(uint8_t)(v >> 24),
+	};
+
+	cdr_align(w, 4);
+	cdr_write_bytes(w, bytes, sizeof(bytes));
+}
+
+static void cdr_write_f32(struct cdr_writer *w, float v)
+{
+	cdr_align(w, 4);
+	cdr_write_bytes(w, &v, sizeof(v));
+}
+
+static void cdr_write_f64(struct cdr_writer *w, double v)
+{
+	cdr_align(w, 8);
+	cdr_write_bytes(w, &v, sizeof(v));
+}
+
+static void cdr_write_string(struct cdr_writer *w, const char *s)
+{
+	size_t len = strlen(s) + 1;
+
+	cdr_write_u32(w, (uint32_t)len);
+	cdr_write_bytes(w, s, len);
+}
+
+static void cdr_write_header(struct cdr_writer *w, struct app_ros_time stamp)
+{
+	static const uint8_t cdr_le_header[CDR_HEADER_SIZE] = {0x00, 0x01, 0x00, 0x00};
+
+	cdr_write_bytes(w, cdr_le_header, sizeof(cdr_le_header));
+	cdr_write_u32(w, stamp.sec);
+	cdr_write_u32(w, stamp.nanosec);
+	cdr_write_string(w, "");
+}
+
+static void cdr_write_f32_nan(struct cdr_writer *w)
+{
+	cdr_write_u32(w, F32_QNAN_LE);
+}
+
+size_t app_ros_encode_battery_state(uint8_t *buf, size_t buf_size, struct app_ros_time stamp,
+				    float voltage, float current)
+{
+	struct cdr_writer w = {
+		.buf = buf,
+		.cap = buf_size,
+		.ok = true,
+	};
+
+	cdr_write_header(&w, stamp);
+	cdr_write_f32(&w, voltage);
+	cdr_write_f32_nan(&w); /* temperature */
+	cdr_write_f32(&w, current);
+	cdr_write_f32_nan(&w); /* charge */
+	cdr_write_f32_nan(&w); /* capacity */
+	cdr_write_f32_nan(&w); /* design_capacity */
+	cdr_write_f32_nan(&w); /* percentage */
+
+	cdr_write_bytes(&w, &(const uint8_t){2}, 1); /* POWER_SUPPLY_STATUS_DISCHARGING */
+	cdr_write_bytes(&w, &(const uint8_t){2}, 1); /* POWER_SUPPLY_HEALTH_GOOD */
+	cdr_write_bytes(&w, &(const uint8_t){0}, 1); /* POWER_SUPPLY_TECHNOLOGY_UNKNOWN */
+	cdr_write_bytes(&w, &(const uint8_t){1}, 1); /* present */
+
+	cdr_write_u32(&w, 0); /* cell_voltage */
+	cdr_write_u32(&w, 0); /* cell_temperature */
+	cdr_write_string(&w, "");
+	cdr_write_string(&w, "");
+
+	return w.ok ? w.len : 0;
+}
+
+size_t app_ros_encode_joint_state(uint8_t *buf, size_t buf_size, struct app_ros_time stamp,
+				  const struct app_ros_joint_sample *joints, size_t joint_count)
+{
+	struct cdr_writer w = {
+		.buf = buf,
+		.cap = buf_size,
+		.ok = true,
+	};
+
+	if (joints == NULL && joint_count != 0) {
+		return 0;
+	}
+
+	cdr_write_header(&w, stamp);
+
+	cdr_write_u32(&w, (uint32_t)joint_count);
+	for (size_t i = 0; i < joint_count; i++) {
+		if (joints[i].name == NULL) {
+			return 0;
+		}
+		cdr_write_string(&w, joints[i].name);
+	}
+
+	cdr_write_u32(&w, (uint32_t)joint_count);
+	for (size_t i = 0; i < joint_count; i++) {
+		cdr_write_f64(&w, joints[i].position);
+	}
+
+	cdr_write_u32(&w, (uint32_t)joint_count);
+	for (size_t i = 0; i < joint_count; i++) {
+		cdr_write_f64(&w, joints[i].velocity);
+	}
+
+	cdr_write_u32(&w, 0); /* effort */
+
+	return w.ok ? w.len : 0;
+}

--- a/applications/rasprover/src/app_ros_cdr.h
+++ b/applications/rasprover/src/app_ros_cdr.h
@@ -1,0 +1,24 @@
+#ifndef APP_ROS_CDR_H
+#define APP_ROS_CDR_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct app_ros_time {
+	uint32_t sec;
+	uint32_t nanosec;
+};
+
+struct app_ros_joint_sample {
+	const char *name;
+	double position;
+	double velocity;
+};
+
+size_t app_ros_encode_battery_state(uint8_t *buf, size_t buf_size, struct app_ros_time stamp,
+				    float voltage, float current);
+
+size_t app_ros_encode_joint_state(uint8_t *buf, size_t buf_size, struct app_ros_time stamp,
+				  const struct app_ros_joint_sample *joints, size_t joint_count);
+
+#endif /* APP_ROS_CDR_H */

--- a/applications/rasprover/src/app_time.c
+++ b/applications/rasprover/src/app_time.c
@@ -1,0 +1,235 @@
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(app_time, LOG_LEVEL_INF);
+
+#include <limits.h>
+#include <string.h>
+#include <time.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net/dns_resolve.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/sntp.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/clock.h>
+
+#include "app_network.h"
+#include "app_time.h"
+
+#define SNTP_SERVER_PORT 123
+
+static void sync_work_handler(struct k_work *work);
+static void sntp_timeout_handler(struct k_work *work);
+static void sntp_service_handler(struct net_socket_service_event *event);
+
+K_WORK_DELAYABLE_DEFINE(sync_work, sync_work_handler);
+K_WORK_DELAYABLE_DEFINE(sntp_timeout_work, sntp_timeout_handler);
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(sntp_service, sntp_service_handler, 1);
+
+static struct sntp_ctx sntp_ctx;
+static struct net_sockaddr_storage sntp_addr;
+static net_socklen_t sntp_addrlen;
+static atomic_t started;
+static atomic_t synced;
+
+static uint32_t sntp_fraction_to_nsec(uint32_t fraction)
+{
+	return (uint32_t)(((uint64_t)fraction * NSEC_PER_SEC) >> 32);
+}
+
+static void schedule_next(bool success)
+{
+	k_work_reschedule(&sync_work, K_SECONDS(success ? CONFIG_APP_TIME_SNTP_RESYNC_SEC
+							: CONFIG_APP_TIME_SNTP_RETRY_SEC));
+}
+
+static bool set_clock_from_sntp(const struct sntp_time *sntp_ts)
+{
+	struct timespec tspec;
+	int ret;
+
+	if (sntp_ts->seconds > LONG_MAX) {
+		LOG_WRN("SNTP seconds value is out of range");
+		return false;
+	}
+
+	tspec.tv_sec = (time_t)sntp_ts->seconds;
+	tspec.tv_nsec = (long)sntp_fraction_to_nsec(sntp_ts->fraction);
+
+	ret = sys_clock_settime(SYS_CLOCK_REALTIME, &tspec);
+	if (ret < 0) {
+		LOG_WRN("setting realtime clock failed: %d", ret);
+		return false;
+	}
+
+	atomic_set(&synced, 1);
+	LOG_INF("time synced via SNTP server %s", CONFIG_APP_TIME_SNTP_SERVER);
+	return true;
+}
+
+static int start_sntp_query(struct net_sockaddr *addr, net_socklen_t addrlen)
+{
+	int ret;
+
+	ret = sntp_init_async(&sntp_ctx, addr, addrlen, &sntp_service);
+	if (ret < 0) {
+		LOG_WRN("SNTP init failed: %d", ret);
+		return ret;
+	}
+
+	ret = sntp_send_async(&sntp_ctx);
+	if (ret < 0) {
+		LOG_WRN("SNTP send failed: %d", ret);
+		sntp_close_async(&sntp_service);
+		return ret;
+	}
+
+	k_work_reschedule(&sntp_timeout_work, K_MSEC(CONFIG_APP_TIME_SNTP_TIMEOUT_MS));
+	return 0;
+}
+
+static bool parse_sntp_server_addr(void)
+{
+	memset(&sntp_addr, 0, sizeof(sntp_addr));
+	sntp_addrlen = 0;
+
+	if (!net_ipaddr_parse(CONFIG_APP_TIME_SNTP_SERVER, sizeof(CONFIG_APP_TIME_SNTP_SERVER) - 1,
+			      net_sad(&sntp_addr))) {
+		return false;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && sntp_addr.ss_family == NET_AF_INET) {
+		sntp_addrlen = sizeof(struct net_sockaddr_in);
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) && sntp_addr.ss_family == NET_AF_INET6) {
+		sntp_addrlen = sizeof(struct net_sockaddr_in6);
+	} else {
+		return false;
+	}
+
+	return net_port_set_default(net_sad(&sntp_addr), SNTP_SERVER_PORT) == 0;
+}
+
+static void dns_result_cb(enum dns_resolve_status status, struct dns_addrinfo *info,
+			  void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	if (status == DNS_EAI_CANCELED || status == DNS_EAI_FAIL) {
+		LOG_WRN("DNS query for SNTP server failed");
+		schedule_next(false);
+		return;
+	}
+
+	if (status == DNS_EAI_ALLDONE) {
+		if (sntp_addrlen == 0) {
+			LOG_WRN("DNS query for SNTP server returned no IPv4 address");
+			schedule_next(false);
+			return;
+		}
+
+		if (start_sntp_query(net_sad(&sntp_addr), sntp_addrlen) < 0) {
+			schedule_next(false);
+		}
+		return;
+	}
+
+	if (status != DNS_EAI_INPROGRESS || info == NULL || sntp_addrlen != 0) {
+		return;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && info->ai_family == NET_AF_INET) {
+		memset(&sntp_addr, 0, sizeof(sntp_addr));
+		sntp_addrlen = info->ai_addrlen;
+		sntp_addr.ss_family = NET_AF_INET;
+		net_ipv4_addr_copy_raw(net_sin(net_sad(&sntp_addr))->sin_addr.s4_addr,
+				       net_sin(&info->ai_addr)->sin_addr.s4_addr);
+		(void)net_port_set_default(net_sad(&sntp_addr), SNTP_SERVER_PORT);
+	}
+}
+
+static void sync_work_handler(struct k_work *work)
+{
+	int ret;
+
+	ARG_UNUSED(work);
+
+	if (!app_net_ipv4_ready()) {
+		LOG_DBG("network is not ready for SNTP");
+		schedule_next(false);
+		return;
+	}
+
+	if (parse_sntp_server_addr()) {
+		if (start_sntp_query(net_sad(&sntp_addr), sntp_addrlen) < 0) {
+			schedule_next(false);
+		}
+		return;
+	}
+
+	memset(&sntp_addr, 0, sizeof(sntp_addr));
+	sntp_addrlen = 0;
+	ret = dns_get_addr_info(CONFIG_APP_TIME_SNTP_SERVER, DNS_QUERY_TYPE_A, NULL, dns_result_cb,
+				NULL, CONFIG_APP_TIME_SNTP_TIMEOUT_MS);
+	if (ret < 0) {
+		LOG_WRN("DNS query for SNTP server could not start: %d", ret);
+		schedule_next(false);
+	}
+}
+
+static void sntp_timeout_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	LOG_WRN("SNTP query timed out");
+	sntp_close_async(&sntp_service);
+	schedule_next(false);
+}
+
+static void sntp_service_handler(struct net_socket_service_event *event)
+{
+	struct sntp_time sntp_ts;
+	bool success = false;
+	int ret;
+
+	ret = sntp_read_async(event, &sntp_ts);
+	if (ret < 0) {
+		LOG_WRN("SNTP read failed: %d", ret);
+	} else {
+		success = set_clock_from_sntp(&sntp_ts);
+	}
+
+	sntp_close_async(&sntp_service);
+	k_work_cancel_delayable(&sntp_timeout_work);
+	schedule_next(success);
+}
+
+void app_time_start(void)
+{
+	if (!atomic_cas(&started, 0, 1)) {
+		return;
+	}
+
+	k_work_schedule(&sync_work, K_NO_WAIT);
+}
+
+bool app_time_synced(void)
+{
+	return atomic_get(&synced) != 0;
+}
+
+struct app_ros_time app_time_now(void)
+{
+	struct timespec tspec;
+
+	if (!app_time_synced()) {
+		return (struct app_ros_time){0};
+	}
+
+	if (sys_clock_gettime(SYS_CLOCK_REALTIME, &tspec) < 0 || tspec.tv_sec < 0 ||
+	    tspec.tv_sec > UINT32_MAX || tspec.tv_nsec < 0 || tspec.tv_nsec >= NSEC_PER_SEC) {
+		return (struct app_ros_time){0};
+	}
+
+	return (struct app_ros_time){
+		.sec = (uint32_t)tspec.tv_sec,
+		.nanosec = (uint32_t)tspec.tv_nsec,
+	};
+}

--- a/applications/rasprover/src/app_time.h
+++ b/applications/rasprover/src/app_time.h
@@ -1,0 +1,29 @@
+#ifndef APP_TIME_H
+#define APP_TIME_H
+
+#include <stdbool.h>
+#include <zephyr/kernel.h>
+
+#include "app_ros_cdr.h"
+
+#if IS_ENABLED(CONFIG_APP_TIME_SYNC)
+void app_time_start(void);
+bool app_time_synced(void);
+struct app_ros_time app_time_now(void);
+#else
+static inline void app_time_start(void)
+{
+}
+
+static inline bool app_time_synced(void)
+{
+	return false;
+}
+
+static inline struct app_ros_time app_time_now(void)
+{
+	return (struct app_ros_time){0};
+}
+#endif
+
+#endif /* APP_TIME_H */

--- a/applications/rasprover/src/app_zenoh.c
+++ b/applications/rasprover/src/app_zenoh.c
@@ -5,112 +5,53 @@ LOG_MODULE_REGISTER(app_zenoh, LOG_LEVEL_INF);
 #include <zenoh-pico.h>
 #include <zephyr/kernel.h>
 
+#include "app_ros_cdr.h"
+#include "app_time.h"
 #include "app_zenoh.h"
 
 #ifdef CONFIG_APP_MOTORS
 #include "app_motors.h"
 #endif
 
-#define BATTERY_STATE_KEY CONFIG_APP_ZENOH_KEY_PREFIX "/battery_state"
-#define CMD_VEL_KEY       CONFIG_APP_ZENOH_KEY_PREFIX "/cmd_vel"
+#define BATTERY_STATE_KEY          CONFIG_APP_ZENOH_KEY_PREFIX "/battery_state"
+#define CDR_BATTERY_STATE_MAX_SIZE 80
 
-/*
- * CDR Little-Endian encoding for sensor_msgs/msg/BatteryState.
- *
- * This is the wire format expected by the zenoh-ros2dds bridge for the ROS2
- * topic that maps to key 'rt/<ns>/battery_state'.
- *
- * Fixed layout (all fields, empty arrays, empty strings):
- *
- *  [0]   CDR LE header          4 B   { 0x00, 0x01, 0x00, 0x00 }
- *  [4]   header.stamp.sec       4 B   u32 LE = 0
- *  [8]   header.stamp.nanosec   4 B   u32 LE = 0
- *  [12]  header.frame_id len    4 B   u32 LE = 1  (empty string: length incl. '\0')
- *  [16]  header.frame_id data   1 B   '\0'
- *  [17]  padding                3 B
- *  [20]  voltage                4 B   f32 LE
- *  [24]  temperature            4 B   f32 LE = NaN
- *  [28]  current                4 B   f32 LE
- *  [32]  charge                 4 B   f32 LE = NaN
- *  [36]  capacity               4 B   f32 LE = NaN
- *  [40]  design_capacity        4 B   f32 LE = NaN
- *  [44]  percentage             4 B   f32 LE = NaN
- *  [48]  power_supply_status    1 B   2 = DISCHARGING
- *  [49]  power_supply_health    1 B   2 = GOOD
- *  [50]  power_supply_technology 1 B  0 = UNKNOWN
- *  [51]  present                1 B   1 = true
- *  [52]  cell_voltage count     4 B   u32 LE = 0
- *  [56]  cell_temperature count 4 B   u32 LE = 0
- *  [60]  location len           4 B   u32 LE = 1
- *  [64]  location data          1 B   '\0'
- *  [65]  padding                3 B
- *  [68]  serial_number len      4 B   u32 LE = 1
- *  [72]  serial_number data     1 B   '\0'
- *  Total: 73 bytes
- */
-#define CDR_BATTERY_STATE_SIZE 73
-
-/* IEEE 754 quiet NaN for float32 (little-endian) */
-static const uint8_t F32_NAN[4] = {0x00, 0x00, 0xC0, 0x7F};
-
-static void write_u32_le(uint8_t *p, uint32_t v)
-{
-	p[0] = (uint8_t)(v);
-	p[1] = (uint8_t)(v >> 8);
-	p[2] = (uint8_t)(v >> 16);
-	p[3] = (uint8_t)(v >> 24);
-}
-
-static size_t encode_battery_state(uint8_t *buf, float voltage, float current)
-{
-	memset(buf, 0, CDR_BATTERY_STATE_SIZE);
-
-	/* CDR LE header */
-	buf[0] = 0x00;
-	buf[1] = 0x01;
-	buf[2] = 0x00;
-	buf[3] = 0x00;
-
-	/* Header.stamp = {0, 0} — already zero */
-
-	/* Header.frame_id = "" */
-	write_u32_le(buf + 12, 1); /* length = 1 (null terminator only) */
-	/* buf[16] = '\0' — already zero; buf[17..19] padding — already zero */
-
-	/* float32 fields */
-	memcpy(buf + 20, &voltage, 4);
-	memcpy(buf + 24, F32_NAN, 4); /* temperature */
-	memcpy(buf + 28, &current, 4);
-	memcpy(buf + 32, F32_NAN, 4); /* charge */
-	memcpy(buf + 36, F32_NAN, 4); /* capacity */
-	memcpy(buf + 40, F32_NAN, 4); /* design_capacity */
-	memcpy(buf + 44, F32_NAN, 4); /* percentage */
-
-	/* status bytes */
-	buf[48] = 2; /* POWER_SUPPLY_STATUS_DISCHARGING */
-	buf[49] = 2; /* POWER_SUPPLY_HEALTH_GOOD */
-	buf[50] = 0; /* POWER_SUPPLY_TECHNOLOGY_UNKNOWN */
-	buf[51] = 1; /* present = true */
-
-	/* cell_voltage / cell_temperature counts = 0 — already zero */
-
-	/* location = "" */
-	write_u32_le(buf + 60, 1);
-	/* buf[64] = '\0'; buf[65..67] padding — already zero */
-
-	/* serial_number = "" */
-	write_u32_le(buf + 68, 1);
-	/* buf[72] = '\0' — already zero */
-
-	return CDR_BATTERY_STATE_SIZE;
-}
+#ifdef CONFIG_APP_MOTORS
+#define CMD_VEL_KEY              CONFIG_APP_ZENOH_KEY_PREFIX "/cmd_vel"
+#define JOINT_STATE_KEY          CONFIG_APP_ZENOH_JOINT_STATE_KEY
+#define CDR_JOINT_STATE_MAX_SIZE 160
+#define JOINT_STATE_INTERVAL_MS  (1000 / CONFIG_APP_ZENOH_JOINT_STATE_PUBLISH_HZ)
+#endif
 
 static z_owned_session_t _session;
 static z_owned_publisher_t _pub_battery;
 #ifdef CONFIG_APP_MOTORS
+static z_owned_publisher_t _pub_joint_state;
 static z_owned_subscriber_t _sub_cmd_vel;
+static struct k_work_delayable _joint_state_work;
+static bool _joint_state_ready;
 #endif
 static bool _ready;
+
+static bool declare_cdr_publisher(z_owned_publisher_t *pub, const char *key)
+{
+	z_view_keyexpr_t ke;
+	z_view_keyexpr_from_str_unchecked(&ke, key);
+
+	z_publisher_options_t pub_opts;
+	z_publisher_options_default(&pub_opts);
+
+	z_owned_encoding_t enc;
+	z_encoding_from_str(&enc, "application/cdr");
+	pub_opts.encoding = z_move(enc);
+
+	if (z_declare_publisher(z_loan(_session), pub, z_loan(ke), &pub_opts) < 0) {
+		LOG_ERR("zenoh publisher declare failed for '%s'", key);
+		return false;
+	}
+
+	return true;
+}
 
 #ifdef CONFIG_APP_MOTORS
 /*
@@ -174,6 +115,44 @@ static bool declare_cmd_vel_subscriber(void)
 	LOG_INF("zenoh subscribed to '%s'", CMD_VEL_KEY);
 	return true;
 }
+
+static void joint_state_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	if (_ready && _joint_state_ready) {
+		struct app_motors_joint_state motor_joints[APP_MOTORS_JOINT_COUNT];
+
+		if (app_motors_read_joint_state(motor_joints)) {
+			struct app_ros_joint_sample joints[APP_MOTORS_JOINT_COUNT];
+			uint8_t buf[CDR_JOINT_STATE_MAX_SIZE];
+
+			for (size_t i = 0; i < ARRAY_SIZE(joints); i++) {
+				joints[i] = (struct app_ros_joint_sample){
+					.name = motor_joints[i].name,
+					.position = motor_joints[i].position_rad,
+					.velocity = motor_joints[i].velocity_rad_s,
+				};
+			}
+
+			size_t len = app_ros_encode_joint_state(buf, sizeof(buf), app_time_now(),
+								joints, ARRAY_SIZE(joints));
+			if (len == 0) {
+				LOG_WRN("joint_states encode failed");
+			} else {
+				z_owned_bytes_t payload;
+
+				z_bytes_copy_from_buf(&payload, buf, len);
+				if (z_publisher_put(z_loan(_pub_joint_state), z_move(payload),
+						    NULL) < 0) {
+					LOG_WRN("joint_states publish failed");
+				}
+			}
+		}
+	}
+
+	k_work_reschedule(&_joint_state_work, K_MSEC(JOINT_STATE_INTERVAL_MS));
+}
 #endif /* CONFIG_APP_MOTORS */
 
 bool app_zenoh_init(void)
@@ -193,42 +172,53 @@ bool app_zenoh_init(void)
 	zp_start_read_task(z_loan_mut(_session), NULL);
 	zp_start_lease_task(z_loan_mut(_session), NULL);
 
-	/* Declare publisher with CDR encoding for zenoh-ros2dds bridge */
-	z_view_keyexpr_t ke;
-	z_view_keyexpr_from_str_unchecked(&ke, BATTERY_STATE_KEY);
-
-	z_publisher_options_t pub_opts;
-	z_publisher_options_default(&pub_opts);
-
-	z_owned_encoding_t enc;
-	z_encoding_from_str(&enc, "application/cdr");
-	pub_opts.encoding = z_move(enc);
-
-	if (z_declare_publisher(z_loan(_session), &_pub_battery, z_loan(ke), &pub_opts) < 0) {
-		LOG_ERR("zenoh publisher declare failed for '%s'", BATTERY_STATE_KEY);
+	if (!declare_cdr_publisher(&_pub_battery, BATTERY_STATE_KEY)) {
 		z_drop(z_move(_session));
 		return false;
 	}
 
 #ifdef CONFIG_APP_MOTORS
+	if (declare_cdr_publisher(&_pub_joint_state, JOINT_STATE_KEY)) {
+		_joint_state_ready = true;
+		k_work_init_delayable(&_joint_state_work, joint_state_work_handler);
+	} else {
+		LOG_WRN("continuing without joint_states publisher");
+	}
+
 	if (!declare_cmd_vel_subscriber()) {
 		LOG_WRN("continuing without cmd_vel subscription");
 	}
 #endif
 
-	LOG_INF("zenoh ready, publishing sensor_msgs/BatteryState to '%s'", BATTERY_STATE_KEY);
 	_ready = true;
+#ifdef CONFIG_APP_MOTORS
+	if (_joint_state_ready) {
+		k_work_schedule(&_joint_state_work, K_NO_WAIT);
+	}
+	LOG_INF("zenoh ready, publishing BatteryState to '%s' and JointState to '%s'",
+		BATTERY_STATE_KEY, JOINT_STATE_KEY);
+#else
+	LOG_INF("zenoh ready, publishing BatteryState to '%s'", BATTERY_STATE_KEY);
+#endif
 	return true;
 }
 
 void app_zenoh_publish_power(double voltage, double current, double power)
 {
+	ARG_UNUSED(power);
+
 	if (!_ready) {
 		return;
 	}
 
-	uint8_t buf[CDR_BATTERY_STATE_SIZE];
-	size_t len = encode_battery_state(buf, (float)voltage, (float)current);
+	uint8_t buf[CDR_BATTERY_STATE_MAX_SIZE];
+	size_t len = app_ros_encode_battery_state(buf, sizeof(buf), app_time_now(), (float)voltage,
+						  (float)current);
+
+	if (len == 0) {
+		LOG_WRN("battery_state encode failed");
+		return;
+	}
 
 	z_owned_bytes_t payload;
 	z_bytes_copy_from_buf(&payload, buf, len);

--- a/applications/rasprover/src/main.c
+++ b/applications/rasprover/src/main.c
@@ -6,6 +6,7 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 #include "app_network.h"
 #include "app_sensors.h"
 #include "app_settings.h"
+#include "app_time.h"
 #include "app_zenoh.h"
 #include <zephyr/kernel.h>
 
@@ -27,6 +28,7 @@ int main(void)
 	app_motors_init();
 #endif
 	app_net_connect();
+	app_time_start();
 	app_zenoh_init();
 
 #ifdef CONFIG_APP_DISPLAY

--- a/tests/rasprover/test_ros_cdr.py
+++ b/tests/rasprover/test_ros_cdr.py
@@ -1,0 +1,88 @@
+import struct
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RASPROVER_SRC = REPO_ROOT / "applications" / "rasprover" / "src"
+
+
+def _compile_and_run(tmp_path: Path, source: str) -> bytes:
+    test_c = tmp_path / "test_ros_cdr.c"
+    test_c.write_text(textwrap.dedent(source))
+    exe = tmp_path / "test_ros_cdr"
+
+    subprocess.run(
+        [
+            "gcc",
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-I",
+            str(RASPROVER_SRC),
+            str(test_c),
+            str(RASPROVER_SRC / "app_ros_cdr.c"),
+            "-o",
+            str(exe),
+        ],
+        check=True,
+    )
+    return subprocess.check_output([exe])
+
+
+def test_joint_state_encoder_publishes_zero_stamp_before_time_sync(tmp_path: Path) -> None:
+    payload = _compile_and_run(
+        tmp_path,
+        r"""
+        #include "app_ros_cdr.h"
+
+        #include <stdint.h>
+        #include <stdio.h>
+
+        int main(void)
+        {
+            uint8_t buf[160];
+            const struct app_ros_joint_sample joints[] = {
+                {
+                    .name = "left_wheel_joint",
+                    .position = 1.25,
+                    .velocity = -0.5,
+                },
+                {
+                    .name = "right_wheel_joint",
+                    .position = -2.5,
+                    .velocity = 0.75,
+                },
+            };
+            const struct app_ros_time stamp = {0};
+            size_t len = app_ros_encode_joint_state(buf, sizeof(buf), stamp, joints, 2);
+
+            fwrite(buf, 1, len, stdout);
+            return 0;
+        }
+        """,
+    )
+
+    assert len(payload) == 120
+    assert payload[:4] == b"\x00\x01\x00\x00"
+    assert struct.unpack_from("<II", payload, 4) == (0, 0)
+
+    assert struct.unpack_from("<I", payload, 12) == (1,)
+    assert payload[16:20] == b"\x00\x00\x00\x00"
+
+    assert struct.unpack_from("<I", payload, 20) == (2,)
+    assert struct.unpack_from("<I", payload, 24) == (17,)
+    assert payload[28:45] == b"left_wheel_joint\x00"
+    assert payload[45:48] == b"\x00\x00\x00"
+    assert struct.unpack_from("<I", payload, 48) == (18,)
+    assert payload[52:70] == b"right_wheel_joint\x00"
+    assert payload[70:72] == b"\x00\x00"
+
+    assert struct.unpack_from("<I", payload, 72) == (2,)
+    assert struct.unpack_from("<dd", payload, 76) == (1.25, -2.5)
+    assert struct.unpack_from("<I", payload, 92) == (2,)
+    assert payload[96:100] == b"\x00\x00\x00\x00"
+    assert struct.unpack_from("<dd", payload, 100) == (-0.5, 0.75)
+    assert struct.unpack_from("<I", payload, 116) == (0,)

--- a/tests/rasprover/test_ros_topics.py
+++ b/tests/rasprover/test_ros_topics.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_joint_state_topic_defaults_to_global_ros_topic() -> None:
+    kconfig = (REPO_ROOT / "applications" / "rasprover" / "Kconfig").read_text()
+    app_zenoh = (REPO_ROOT / "applications" / "rasprover" / "src" / "app_zenoh.c").read_text()
+
+    assert "config APP_ZENOH_JOINT_STATE_KEY" in kconfig
+    assert 'default "rt/joint_states"' in kconfig
+    assert '#define JOINT_STATE_KEY          CONFIG_APP_ZENOH_JOINT_STATE_KEY' in app_zenoh


### PR DESCRIPTION
## Summary
- publish wheel feedback as sensor_msgs/JointState on rt/joint_states so ROS sees /joint_states
- add SNTP-backed realtime stamping with zero timestamps until first sync
- move ROS CDR encoding into shared helpers with focused pytest coverage

## Test Plan
- rtk uv run pytest tests/rasprover -q
- rtk uv run clang-format --dry-run --Werror applications/rasprover/src/app_ros_cdr.c applications/rasprover/src/app_ros_cdr.h applications/rasprover/src/app_time.c applications/rasprover/src/app_time.h applications/rasprover/src/app_network.c applications/rasprover/src/app_network.h applications/rasprover/src/app_motors.c applications/rasprover/src/app_motors.h applications/rasprover/src/app_zenoh.c applications/rasprover/src/main.c
- rtk git diff --check --cached
- rtk uv run poe agent-build rasprover --sysbuild
- rtk uv run poe agent-build rasprover --board native_sim/native/64