### PR TITLE
test: scope pytest collection to tests/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,5 +89,10 @@ disallow_incomplete_defs = true
 disallow_untyped_decorators = true
 disallow_any_unimported = false
 
+[tool.pytest.ini_options]
+# Only collect this repo's own tests; keep pytest out of deps/ where upstream
+# module test scripts call sys.exit() at import and abort collection.
+testpaths = ["tests"]
+
 [tool.poe]
 include = "poe.toml"


### PR DESCRIPTION
## Summary

Adds `[tool.pytest.ini_options] testpaths = ["tests"]` to `pyproject.toml` so a bare `uv run pytest` collects only this repo's own tests.

Without it, pytest walks from the rootdir into `deps/` and hits an upstream lvgl module test (`deps/modules/lib/gui/lvgl/tests/gen_json/test_gen_json.py`) that calls `sys.exit()` at import time, aborting the entire run with an `INTERNALERROR`. Running `uv run pytest tests/` worked around it; this makes the bare invocation correct.

## Verification

- Before: `uv run pytest` → `5 errors` (collection aborts in `deps/`).
- After: `uv run pytest` → **7 passed**, `testpaths: tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)