### PR TITLE
test: rename sample.yaml to tests.yaml and namespace twister scenarios

### DIFF
--- a/applications/joystick_controller/tests.yaml
+++ b/applications/joystick_controller/tests.yaml
@@ -2,14 +2,14 @@
 # the Zephyr testing tool. In this file, multiple combinations can be specified,
 # so that you can easily test all of them locally or in CI.
 sample:
-  description: Motor Controller application
-  name: motor-controller-application 
+  description: Joystick controller application
+  name: joystick-controller
 common:
   build_only: true
   integration_platforms:
-    - robotis_openrb_150
+    - adafruit_qt_py_esp32s3/esp32s3/procpu
 tests:
-  app.default: {}
-  app.debug:
-    extra_overlay_confs:
-      - debug.conf
+  app.joystick_controller.default: {}
+#  app.joystick_controller.debug:
+#    extra_overlay_confs:
+#      - debug.conf

--- a/applications/motor_controller/tests.yaml
+++ b/applications/motor_controller/tests.yaml
@@ -2,14 +2,14 @@
 # the Zephyr testing tool. In this file, multiple combinations can be specified,
 # so that you can easily test all of them locally or in CI.
 sample:
-  description: Joystick controller application
-  name: joystick-controller 
+  description: Motor Controller application
+  name: motor-controller-application
 common:
   build_only: true
   integration_platforms:
-    - adafruit_qt_py_esp32s3/esp32s3/procpu
+    - robotis_openrb_150
 tests:
-  app.default: {}
-#  app.debug:
-#    extra_overlay_confs:
-#      - debug.conf
+  app.motor_controller.default: {}
+  app.motor_controller.debug:
+    extra_overlay_confs:
+      - debug.conf

--- a/applications/pico_fw/tests.yaml
+++ b/applications/pico_fw/tests.yaml
@@ -2,14 +2,14 @@
 # the Zephyr testing tool. In this file, multiple combinations can be specified,
 # so that you can easily test all of them locally or in CI.
 sample:
-  description: ROS Driver application
-  name: ros-driver 
+  description: Pico firmware application
+  name: pico-fw
 common:
   build_only: true
   integration_platforms:
-    - ros_driver
+    - rpi_pico/rp2040/w
 tests:
-  app.default: {}
-  app.debug:
+  app.pico_fw.default: {}
+  app.pico_fw.debug:
     extra_overlay_confs:
       - debug.conf

--- a/applications/rasprover/tests.yaml
+++ b/applications/rasprover/tests.yaml
@@ -2,14 +2,14 @@
 # the Zephyr testing tool. In this file, multiple combinations can be specified,
 # so that you can easily test all of them locally or in CI.
 sample:
-  description: Example application
-  name: example-application
+  description: ROS Driver application
+  name: ros-driver
 common:
   build_only: true
   integration_platforms:
-    - rpi_pico/rp2040/w
+    - ros_driver/esp32/procpu
 tests:
-  app.default: {}
-  app.debug:
+  app.rasprover.default: {}
+  app.rasprover.debug:
     extra_overlay_confs:
       - debug.conf


### PR DESCRIPTION
## Summary
- Rename `sample.yaml` → `tests.yaml` in all four apps, following upstream filename unification (zephyrproject-rtos/example-application#102). The pinned Zephyr's twister already accepts the new name.
- Namespace twister scenario names per app (`app.default` → `app.<app>.default`): twister now keys suites by bare scenario name globally, so the duplicated `app.default` across apps raised `Duplicate test suite` errors.
- Fix rasprover's `integration_platforms` to the fully qualified `ros_driver/esp32/procpu` (bare `ros_driver` was rejected as an unrecognized platform).
- Replace pico_fw's leftover template sample name (`example-application` → `pico-fw`).

## Testing
- `uv run west twister --list-tests -T applications` discovers all 7 scenarios with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)