### PR TITLE
bt_keys: add USB HID transport (esp32s3)

### DIFF
--- a/applications/bt_keys/CMakeLists.txt
+++ b/applications/bt_keys/CMakeLists.txt
@@ -7,4 +7,7 @@ target_sources(app PRIVATE
   src/main.c
   src/hog.c
   src/keys.c
+  src/report_desc.c
 )
+
+target_sources_ifdef(CONFIG_USB_DEVICE_STACK_NEXT app PRIVATE src/usb_hid.c)

--- a/applications/bt_keys/README.md
+++ b/applications/bt_keys/README.md
@@ -22,6 +22,10 @@ updatable wirelessly over Bluetooth (MCUmgr SMP + MCUboot).
   cyan for visual feedback.
 - The HID report map exposes **two** input reports so a key can emit either a
   standard keyboard usage or a consumer-control (media) usage.
+- On the `adafruit_qt_py_esp32s3` board target, key presses are also sent over
+  a USB HID interface (same report map), in addition to BLE HoG. The
+  `adafruit_qt_py_esp32c3` target has no USB device controller and stays
+  BLE-only.
 
 ### Key mapping
 

--- a/applications/bt_keys/boards/adafruit_qt_py_esp32s3_esp32s3_procpu.conf
+++ b/applications/bt_keys/boards/adafruit_qt_py_esp32s3_esp32s3_procpu.conf
@@ -1,0 +1,5 @@
+# USB HID keypad, in addition to the BLE HoG one. esp32c3 has no USB device
+# controller, so this is enabled only for the esp32s3 board target.
+CONFIG_USB_DEVICE_STACK_NEXT=y
+CONFIG_USBD_HID_SUPPORT=y
+CONFIG_HWINFO=y

--- a/applications/bt_keys/boards/adafruit_qt_py_esp32s3_esp32s3_procpu.overlay
+++ b/applications/bt_keys/boards/adafruit_qt_py_esp32s3_esp32s3_procpu.overlay
@@ -8,6 +8,18 @@
 
 #include <zephyr/dt-bindings/led/led.h>
 
+/* USB HID keypad, alongside the BLE HoG one - see boards/*.conf. */
+zephyr_udc0: &usb_otg {
+	status = "okay";
+
+	usb_hid: usb_hid {
+		compatible = "zephyr,hid-device";
+		protocol-code = "none";
+		in-report-size = <9>;
+		in-polling-period-us = <10000>;
+	};
+};
+
 &zephyr_i2c {
 	status = "okay";
 

--- a/applications/bt_keys/src/hog.c
+++ b/applications/bt_keys/src/hog.c
@@ -44,9 +44,6 @@ struct hids_report {
 	uint8_t type;
 } __packed;
 
-#define REPORT_ID_KEYBOARD 0x01
-#define REPORT_ID_CONSUMER 0x02
-
 static struct hids_info info = {
 	.version = 0x0111,
 	.code = 0x00,
@@ -63,54 +60,6 @@ static struct hids_report consumer_ref = {
 	.type = HIDS_INPUT,
 };
 
-/*
- * Report map: a keyboard collection (report id 1, 8-byte report) and a consumer
- * collection (report id 2, one 16-bit usage). Standard HID descriptors.
- */
-/* clang-format off */
-static const uint8_t report_map[] = {
-	/* Keyboard */
-	0x05, 0x01,               /* Usage Page (Generic Desktop) */
-	0x09, 0x06,               /* Usage (Keyboard) */
-	0xA1, 0x01,               /* Collection (Application) */
-	0x85, REPORT_ID_KEYBOARD, /*  Report ID (1) */
-	0x05, 0x07,               /*  Usage Page (Keyboard/Keypad) */
-	0x19, 0xE0,               /*  Usage Minimum (Left Control) */
-	0x29, 0xE7,               /*  Usage Maximum (Right GUI) */
-	0x15, 0x00,               /*  Logical Minimum (0) */
-	0x25, 0x01,               /*  Logical Maximum (1) */
-	0x75, 0x01,               /*  Report Size (1) */
-	0x95, 0x08,               /*  Report Count (8) */
-	0x81, 0x02,               /*  Input (Data,Var,Abs) - modifier byte */
-	0x95, 0x01,               /*  Report Count (1) */
-	0x75, 0x08,               /*  Report Size (8) */
-	0x81, 0x03,               /*  Input (Const) - reserved byte */
-	0x95, 0x06,               /*  Report Count (6) */
-	0x75, 0x08,               /*  Report Size (8) */
-	0x15, 0x00,               /*  Logical Minimum (0) */
-	0x25, 0xFF,               /*  Logical Maximum (255) */
-	0x05, 0x07,               /*  Usage Page (Keyboard/Keypad) */
-	0x19, 0x00,               /*  Usage Minimum (0) */
-	0x29, 0xFF,               /*  Usage Maximum (255) */
-	0x81, 0x00,               /*  Input (Data,Array) - keycodes */
-	0xC0,                     /* End Collection */
-
-	/* Consumer control */
-	0x05, 0x0C,               /* Usage Page (Consumer) */
-	0x09, 0x01,               /* Usage (Consumer Control) */
-	0xA1, 0x01,               /* Collection (Application) */
-	0x85, REPORT_ID_CONSUMER, /*  Report ID (2) */
-	0x15, 0x00,               /*  Logical Minimum (0) */
-	0x26, 0xFF, 0x03,         /*  Logical Maximum (0x3FF) */
-	0x19, 0x00,               /*  Usage Minimum (0) */
-	0x2A, 0xFF, 0x03,         /*  Usage Maximum (0x3FF) */
-	0x75, 0x10,               /*  Report Size (16) */
-	0x95, 0x01,               /*  Report Count (1) */
-	0x81, 0x00,               /*  Input (Data,Array) */
-	0xC0,                     /* End Collection */
-};
-/* clang-format on */
-
 static uint8_t keyboard_notify;
 static uint8_t consumer_notify;
 static uint8_t ctrl_point;
@@ -125,7 +74,8 @@ static ssize_t read_info(struct bt_conn *conn, const struct bt_gatt_attr *attr, 
 static ssize_t read_report_map(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, report_map, sizeof(report_map));
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, hid_report_desc,
+				 hid_report_desc_len);
 }
 
 static ssize_t read_report(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
@@ -193,16 +143,22 @@ BT_GATT_SERVICE_DEFINE(
 #define ATTR_KEYBOARD_REPORT 6
 #define ATTR_CONSUMER_REPORT 10
 
-void hog_notify_keyboard(uint8_t modifiers, const uint8_t keycodes[HOG_KEYBOARD_KEYS])
+void hog_notify_keyboard(uint8_t modifiers, const uint8_t keycodes[HID_KEYBOARD_KEYS])
 {
 	if (!keyboard_notify) {
 		return;
 	}
 
-	uint8_t report[2 + HOG_KEYBOARD_KEYS] = {modifiers, 0};
+	uint8_t report[2 + HID_KEYBOARD_KEYS] = {modifiers, 0};
 
-	memcpy(&report[2], keycodes, HOG_KEYBOARD_KEYS);
-	bt_gatt_notify(NULL, &hog_svc.attrs[ATTR_KEYBOARD_REPORT], report, sizeof(report));
+	memcpy(&report[2], keycodes, HID_KEYBOARD_KEYS);
+
+	int err =
+		bt_gatt_notify(NULL, &hog_svc.attrs[ATTR_KEYBOARD_REPORT], report, sizeof(report));
+
+	if (err) {
+		LOG_WRN("keyboard notify failed: %d", err);
+	}
 }
 
 void hog_notify_consumer(uint16_t usage)
@@ -214,5 +170,11 @@ void hog_notify_consumer(uint16_t usage)
 	uint8_t report[2];
 
 	sys_put_le16(usage, report);
-	bt_gatt_notify(NULL, &hog_svc.attrs[ATTR_CONSUMER_REPORT], report, sizeof(report));
+
+	int err =
+		bt_gatt_notify(NULL, &hog_svc.attrs[ATTR_CONSUMER_REPORT], report, sizeof(report));
+
+	if (err) {
+		LOG_WRN("consumer notify failed: %d", err);
+	}
 }

--- a/applications/bt_keys/src/hog.h
+++ b/applications/bt_keys/src/hog.h
@@ -9,15 +9,14 @@
 
 #include <stdint.h>
 
-/* Keyboard input report: [modifiers][reserved][keycode x6]. */
-#define HOG_KEYBOARD_KEYS 6
+#include "report_desc.h"
 
 /*
  * Notify the connected host of the current keyboard state. keycodes holds up
- * to HOG_KEYBOARD_KEYS pressed HID keyboard usages (0 = empty slot). No-op if
+ * to HID_KEYBOARD_KEYS pressed HID keyboard usages (0 = empty slot). No-op if
  * no host has subscribed to the keyboard report.
  */
-void hog_notify_keyboard(uint8_t modifiers, const uint8_t keycodes[HOG_KEYBOARD_KEYS]);
+void hog_notify_keyboard(uint8_t modifiers, const uint8_t keycodes[HID_KEYBOARD_KEYS]);
 
 /*
  * Notify the connected host of the current consumer-control state. usage is the

--- a/applications/bt_keys/src/main.c
+++ b/applications/bt_keys/src/main.c
@@ -26,6 +26,7 @@
 
 #include "hog.h"
 #include "keys.h"
+#include "usb_hid.h"
 
 LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
@@ -174,35 +175,73 @@ static void leds_update(int pressed_mask)
 /* Translate the pressed mask into HID reports and notify on change. */
 static void report_keys(int pressed_mask)
 {
-	static uint8_t prev_kbd[HOG_KEYBOARD_KEYS];
+	static uint8_t prev_kbd[HID_KEYBOARD_KEYS];
 	static uint16_t prev_consumer;
+	static int prev_mask;
+	/*
+	 * The consumer report carries a single 16-bit usage, so at most one held
+	 * consumer key can be reported at a time. A newly pressed consumer key
+	 * takes over from an older held one; releasing the active key falls back
+	 * to another still-held consumer key, if any.
+	 */
+	static int active_consumer_key = -1;
 
-	uint8_t kbd[HOG_KEYBOARD_KEYS] = {0};
+	uint8_t kbd[HID_KEYBOARD_KEYS] = {0};
 	uint16_t consumer = 0;
 	int kbd_idx = 0;
+
+	if (active_consumer_key >= 0 && !(pressed_mask & BIT(active_consumer_key))) {
+		active_consumer_key = -1;
+	}
+
+	for (int i = 0; i < BT_KEYS_NUM_KEYS; i++) {
+		bool newly_pressed = (pressed_mask & BIT(i)) && !(prev_mask & BIT(i));
+
+		if (newly_pressed && bt_keys_map[i].type == BT_KEYS_TYPE_CONSUMER) {
+			active_consumer_key = i;
+		}
+	}
+
+	if (active_consumer_key < 0) {
+		for (int i = 0; i < BT_KEYS_NUM_KEYS; i++) {
+			if ((pressed_mask & BIT(i)) &&
+			    bt_keys_map[i].type == BT_KEYS_TYPE_CONSUMER) {
+				active_consumer_key = i;
+				break;
+			}
+		}
+	}
+
+	if (active_consumer_key >= 0) {
+		consumer = bt_keys_map[active_consumer_key].usage;
+	}
 
 	for (int i = 0; i < BT_KEYS_NUM_KEYS; i++) {
 		if (!(pressed_mask & BIT(i))) {
 			continue;
 		}
 
-		if (bt_keys_map[i].type == BT_KEYS_TYPE_CONSUMER) {
-			if (consumer == 0) {
-				consumer = bt_keys_map[i].usage;
-			}
-		} else if (kbd_idx < HOG_KEYBOARD_KEYS) {
+		if (bt_keys_map[i].type == BT_KEYS_TYPE_KEYBOARD && kbd_idx < HID_KEYBOARD_KEYS) {
 			kbd[kbd_idx++] = (uint8_t)bt_keys_map[i].usage;
 		}
 	}
 
+	prev_mask = pressed_mask;
+
 	if (memcmp(kbd, prev_kbd, sizeof(kbd)) != 0) {
 		memcpy(prev_kbd, kbd, sizeof(kbd));
 		hog_notify_keyboard(0, kbd);
+		if (IS_ENABLED(CONFIG_USB_DEVICE_STACK_NEXT)) {
+			usb_hid_notify_keyboard(0, kbd);
+		}
 	}
 
 	if (consumer != prev_consumer) {
 		prev_consumer = consumer;
 		hog_notify_consumer(consumer);
+		if (IS_ENABLED(CONFIG_USB_DEVICE_STACK_NEXT)) {
+			usb_hid_notify_consumer(consumer);
+		}
 	}
 }
 
@@ -221,6 +260,14 @@ int main(void)
 		return 0;
 	}
 	leds_update(0);
+
+	if (IS_ENABLED(CONFIG_USB_DEVICE_STACK_NEXT)) {
+		err = bt_keys_usb_hid_init();
+		if (err) {
+			LOG_ERR("usb_hid_init failed (err %d)", err);
+			return 0;
+		}
+	}
 
 	err = bt_enable(bt_ready);
 	if (err) {

--- a/applications/bt_keys/src/report_desc.c
+++ b/applications/bt_keys/src/report_desc.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Richard Osterloh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "report_desc.h"
+
+/* clang-format off */
+const uint8_t hid_report_desc[] = {
+	/* Keyboard */
+	0x05, 0x01,               /* Usage Page (Generic Desktop) */
+	0x09, 0x06,               /* Usage (Keyboard) */
+	0xA1, 0x01,               /* Collection (Application) */
+	0x85, REPORT_ID_KEYBOARD, /*  Report ID (1) */
+	0x05, 0x07,               /*  Usage Page (Keyboard/Keypad) */
+	0x19, 0xE0,               /*  Usage Minimum (Left Control) */
+	0x29, 0xE7,               /*  Usage Maximum (Right GUI) */
+	0x15, 0x00,               /*  Logical Minimum (0) */
+	0x25, 0x01,               /*  Logical Maximum (1) */
+	0x75, 0x01,               /*  Report Size (1) */
+	0x95, 0x08,               /*  Report Count (8) */
+	0x81, 0x02,               /*  Input (Data,Var,Abs) - modifier byte */
+	0x95, 0x01,               /*  Report Count (1) */
+	0x75, 0x08,               /*  Report Size (8) */
+	0x81, 0x03,               /*  Input (Const) - reserved byte */
+	0x95, 0x06,               /*  Report Count (6) */
+	0x75, 0x08,               /*  Report Size (8) */
+	0x15, 0x00,               /*  Logical Minimum (0) */
+	0x25, 0xFF,               /*  Logical Maximum (255) */
+	0x05, 0x07,               /*  Usage Page (Keyboard/Keypad) */
+	0x19, 0x00,               /*  Usage Minimum (0) */
+	0x29, 0xFF,               /*  Usage Maximum (255) */
+	0x81, 0x00,               /*  Input (Data,Array) - keycodes */
+	0xC0,                     /* End Collection */
+
+	/* Consumer control */
+	0x05, 0x0C,               /* Usage Page (Consumer) */
+	0x09, 0x01,               /* Usage (Consumer Control) */
+	0xA1, 0x01,               /* Collection (Application) */
+	0x85, REPORT_ID_CONSUMER, /*  Report ID (2) */
+	0x15, 0x00,               /*  Logical Minimum (0) */
+	0x26, 0xFF, 0x03,         /*  Logical Maximum (0x3FF) */
+	0x19, 0x00,               /*  Usage Minimum (0) */
+	0x2A, 0xFF, 0x03,         /*  Usage Maximum (0x3FF) */
+	0x75, 0x10,               /*  Report Size (16) */
+	0x95, 0x01,               /*  Report Count (1) */
+	0x81, 0x00,               /*  Input (Data,Array) */
+	0xC0,                     /* End Collection */
+};
+/* clang-format on */
+
+const size_t hid_report_desc_len = sizeof(hid_report_desc);

--- a/applications/bt_keys/src/report_desc.h
+++ b/applications/bt_keys/src/report_desc.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Richard Osterloh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * HID report descriptor shared by both HID transports (BLE HoG and USB HID):
+ * a keyboard collection (report id 1, 8-byte report) and a consumer-control
+ * collection (report id 2, one 16-bit usage).
+ */
+
+#ifndef BT_KEYS_REPORT_DESC_H_
+#define BT_KEYS_REPORT_DESC_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define REPORT_ID_KEYBOARD 0x01
+#define REPORT_ID_CONSUMER 0x02
+
+/* Keyboard input report: [modifiers][reserved][keycode x6]. */
+#define HID_KEYBOARD_KEYS 6
+
+extern const uint8_t hid_report_desc[];
+extern const size_t hid_report_desc_len;
+
+#endif /* BT_KEYS_REPORT_DESC_H_ */

--- a/applications/bt_keys/src/usb_hid.c
+++ b/applications/bt_keys/src/usb_hid.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Richard Osterloh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * USB HID transport: same two reports (keyboard + consumer) as the BLE HoG
+ * service, sent over a single HID class instance instead of GATT notifications.
+ */
+
+#include <string.h>
+
+#include <zephyr/drivers/usb/udc.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/usb/class/usbd_hid.h>
+#include <zephyr/usb/usbd.h>
+
+#include <zephyr/logging/log.h>
+
+#include "usb_hid.h"
+
+LOG_MODULE_REGISTER(usb_hid, LOG_LEVEL_INF);
+
+#define APP_USB_VID 0x2fe3
+#define APP_USB_PID 0x0002
+
+static const struct device *const hid_dev = DEVICE_DT_GET(DT_NODELABEL(usb_hid));
+
+static bool hid_ready;
+
+static void hid_iface_ready(const struct device *dev, const bool ready)
+{
+	ARG_UNUSED(dev);
+	hid_ready = ready;
+}
+
+static const struct hid_device_ops hid_ops = {
+	.iface_ready = hid_iface_ready,
+};
+
+USBD_DEVICE_DEFINE(bt_keys_usbd, DEVICE_DT_GET(DT_NODELABEL(zephyr_udc0)), APP_USB_VID,
+		   APP_USB_PID);
+USBD_DESC_LANG_DEFINE(usbd_lang);
+USBD_DESC_MANUFACTURER_DEFINE(usbd_mfr, "rosterloh");
+USBD_DESC_PRODUCT_DEFINE(usbd_product, "bt_keys");
+USBD_DESC_SERIAL_NUMBER_DEFINE(usbd_sn);
+USBD_DESC_CONFIG_DEFINE(usbd_fs_cfg_desc, "FS Configuration");
+USBD_CONFIGURATION_DEFINE(usbd_fs_config, USB_SCD_SELF_POWERED, 100, &usbd_fs_cfg_desc);
+
+int bt_keys_usb_hid_init(void)
+{
+	int err;
+
+	err = hid_device_register(hid_dev, hid_report_desc, hid_report_desc_len, &hid_ops);
+	if (err) {
+		LOG_ERR("hid_device_register failed (%d)", err);
+		return err;
+	}
+
+	err = usbd_add_descriptor(&bt_keys_usbd, &usbd_lang);
+	err |= usbd_add_descriptor(&bt_keys_usbd, &usbd_mfr);
+	err |= usbd_add_descriptor(&bt_keys_usbd, &usbd_product);
+	err |= usbd_add_descriptor(&bt_keys_usbd, &usbd_sn);
+	if (err) {
+		LOG_ERR("failed to add USB string descriptors (%d)", err);
+		return err;
+	}
+
+	err = usbd_add_configuration(&bt_keys_usbd, USBD_SPEED_FS, &usbd_fs_config);
+	if (err) {
+		LOG_ERR("usbd_add_configuration failed (%d)", err);
+		return err;
+	}
+
+	err = usbd_register_all_classes(&bt_keys_usbd, USBD_SPEED_FS, 1, NULL);
+	if (err) {
+		LOG_ERR("usbd_register_all_classes failed (%d)", err);
+		return err;
+	}
+
+	err = usbd_init(&bt_keys_usbd);
+	if (err) {
+		LOG_ERR("usbd_init failed (%d)", err);
+		return err;
+	}
+
+	err = usbd_enable(&bt_keys_usbd);
+	if (err) {
+		LOG_ERR("usbd_enable failed (%d)", err);
+		return err;
+	}
+
+	LOG_INF("USB HID ready");
+	return 0;
+}
+
+void usb_hid_notify_keyboard(uint8_t modifiers, const uint8_t keycodes[HID_KEYBOARD_KEYS])
+{
+	if (!hid_ready) {
+		return;
+	}
+
+	uint8_t report[1 + 2 + HID_KEYBOARD_KEYS] = {REPORT_ID_KEYBOARD, modifiers, 0};
+
+	memcpy(&report[3], keycodes, HID_KEYBOARD_KEYS);
+
+	int err = hid_device_submit_report(hid_dev, sizeof(report), report);
+
+	if (err) {
+		LOG_WRN("keyboard report submit failed: %d", err);
+	}
+}
+
+void usb_hid_notify_consumer(uint16_t usage)
+{
+	if (!hid_ready) {
+		return;
+	}
+
+	uint8_t report[3] = {REPORT_ID_CONSUMER};
+
+	sys_put_le16(usage, &report[1]);
+
+	int err = hid_device_submit_report(hid_dev, sizeof(report), report);
+
+	if (err) {
+		LOG_WRN("consumer report submit failed: %d", err);
+	}
+}

--- a/applications/bt_keys/src/usb_hid.h
+++ b/applications/bt_keys/src/usb_hid.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Richard Osterloh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef BT_KEYS_USB_HID_H_
+#define BT_KEYS_USB_HID_H_
+
+#include <stdint.h>
+
+#include "report_desc.h"
+
+/*
+ * Bring up the USB device stack and the HID class instance. Only built when
+ * CONFIG_USB_DEVICE_STACK_NEXT is enabled (currently the esp32s3 board target
+ * only - esp32c3 has no USB device controller for a HID class).
+ */
+int bt_keys_usb_hid_init(void);
+
+/* Same semantics as hog_notify_keyboard(), for the USB HID transport. */
+void usb_hid_notify_keyboard(uint8_t modifiers, const uint8_t keycodes[HID_KEYBOARD_KEYS]);
+
+/* Same semantics as hog_notify_consumer(), for the USB HID transport. */
+void usb_hid_notify_consumer(uint16_t usage);
+
+#endif /* BT_KEYS_USB_HID_H_ */


### PR DESCRIPTION
## Summary
- Key presses now report over USB HID in addition to BLE HoG when built for `adafruit_qt_py_esp32s3`, which has a real USB device controller (`usb_otg`/dwc2). `adafruit_qt_py_esp32c3` has none (only USB-Serial-JTAG, already used for the shell console) and stays BLE-only — gated via a board-specific Kconfig fragment + `CONFIG_USB_DEVICE_STACK_NEXT`.
- The HID report descriptor (keyboard + consumer, previously duplicated) is now shared between `hog.c` and the new `usb_hid.c` via `report_desc.{c,h}`.
- Notify/submit failures on both transports are now logged instead of silently dropped.
- `report_keys()` now handles two simultaneously held consumer-type keys correctly: the most recently pressed one wins, falling back to another still-held one on release, instead of always favoring the lowest key index.

## Test plan
- [x] `uv run poe agent-build bt_keys --sysbuild` (esp32c3, default) — builds clean, BLE-only as before
- [x] `uv run poe agent-build bt_keys --board "adafruit_qt_py_esp32s3@psram/esp32s3/procpu" --sysbuild` — builds clean with USB HID enabled
- [x] `uv run clang-format --dry-run --Werror` on all changed/new sources
- [ ] Flash + verify USB HID keypresses land on a host (not done — no S3 hardware in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)