### PR TITLE
skills: revalidate against Zephyr a632b9723bab, finish mise migration

### DIFF
--- a/.claude/skills/.symbol-allowlist.txt
+++ b/.claude/skills/.symbol-allowlist.txt
@@ -1,5 +1,5 @@
 # CONFIG_* symbols cited in .claude/skills/ that intentionally do not exist in
-# deps/. Checked by scripts/check_skill_symbols.py (uv run poe check-skills).
+# deps/. Checked by scripts/check_skill_symbols.py (mise run check-skills).
 #
 # Format: one fnmatch glob per line, `#` starts a trailing reason.
 # Keep a reason on every entry -- an unexplained entry is indistinguishable

--- a/.claude/skills/zephyr-connectivity/SKILL.md
+++ b/.claude/skills/zephyr-connectivity/SKILL.md
@@ -14,7 +14,7 @@ description: >
 
 # Zephyr Connectivity
 
-Validated against: Zephyr 4.4.99 (b3e7c445b343, 2026-07-26). Re-check with `uv run poe check-skills`.
+Validated against: Zephyr 4.4.99 (a632b9723bab, 2026-08-07). Re-check with `mise run check-skills`.
 
 ## Scope
 

--- a/.claude/skills/zephyr-connectivity/references/bluetooth-le.md
+++ b/.claude/skills/zephyr-connectivity/references/bluetooth-le.md
@@ -1734,7 +1734,7 @@ Two related stack limits hit while tracing the same bug:
 ### A stale bond partition makes the first fresh pairing fail
 
 On the C3, leftover ZMS content produced `Security failed: level 1 err 4` on a
-first pairing attempt. `poe flash` does not erase the storage partition — do a
+first pairing attempt. `mise run flash` does not erase the storage partition — do a
 full `esptool erase-flash` and reflash, then pairing succeeds. See
 `../../zephyr-system/references/storage.md`.
 

--- a/.claude/skills/zephyr-connectivity/references/wifi.md
+++ b/.claude/skills/zephyr-connectivity/references/wifi.md
@@ -1599,6 +1599,6 @@ the iface admin-up itself, and with
 then, so an `admin_up` early-return deadlocks the retry.
 
 Recovery for an already-wedged board: a full chip erase clears the stored
-credential (`uv run esptool --port <port> erase-flash`, then reflash) — a plain
-`poe flash` does not, because it only erases the app region. See
+credential (`mise x -- esptool --port <port> erase-flash`, then reflash) — a plain
+`mise run flash` does not, because it only erases the app region. See
 `../../zephyr-system/references/storage.md`.

--- a/.claude/skills/zephyr-debugging/SKILL.md
+++ b/.claude/skills/zephyr-debugging/SKILL.md
@@ -21,7 +21,7 @@ description: >
 
 # Zephyr Debugging
 
-Validated against: Zephyr 4.4.99 (b3e7c445b343, 2026-07-26). Re-check with `uv run poe check-skills`.
+Validated against: Zephyr 4.4.99 (a632b9723bab, 2026-08-07). Re-check with `mise run check-skills`.
 
 Debugging a flashed Zephyr board spans several transports and tools. They're
 not interchangeable — each answers a different question. Pick by **what you
@@ -102,5 +102,5 @@ Load only the one the table points you at:
 - **Capture loosely, filter post-hoc.** Aggressive live filters (serial
   monitor lines, tshark display filters) routinely eat the one error you
   needed. Log to a file, `grep` afterwards.
-- **Run python in the project venv** (`uv run python3 ...`) or pyserial and
+- **Run python in the project venv** (`mise x -- python3 ...`) or pyserial and
   friends won't import.

--- a/.claude/skills/zephyr-debugging/references/coredump.md
+++ b/.claude/skills/zephyr-debugging/references/coredump.md
@@ -32,11 +32,11 @@ Zephyr ships the tooling under `scripts/coredump/`:
 
 ```
 # 1. turn the captured log block into a coredump binary
-uv run python $ZEPHYR_BASE/scripts/coredump/coredump_serial_log_parser.py \
+mise x -- python $ZEPHYR_BASE/scripts/coredump/coredump_serial_log_parser.py \
     boot.log coredump.bin
 
 # 2. start a gdbserver that speaks the coredump
-uv run python $ZEPHYR_BASE/scripts/coredump/coredump_gdbserver.py \
+mise x -- python $ZEPHYR_BASE/scripts/coredump/coredump_gdbserver.py \
     builds/<app>/zephyr/zephyr.elf coredump.bin
 
 # 3. connect normal gdb to it

--- a/.claude/skills/zephyr-debugging/references/gdb.md
+++ b/.claude/skills/zephyr-debugging/references/gdb.md
@@ -16,9 +16,9 @@ backtrace. gdb attaches through the same debug probe as RTT.
 
 west wraps the probe + gdb for you:
 ```
-uv run west debug   -d builds/<app>     # flash, reset, attach, halt at main
-uv run west attach  -d builds/<app>     # attach to a *running* target, no reset
-uv run west debugserver -d builds/<app> # just the gdbserver; connect gdb yourself
+mise x -- west debug   -d builds/<app>     # flash, reset, attach, halt at main
+mise x -- west attach  -d builds/<app>     # attach to a *running* target, no reset
+mise x -- west debugserver -d builds/<app> # just the gdbserver; connect gdb yourself
 ```
 `west attach` is the one you usually want when chasing a live hang — it
 doesn't reset, so you catch the system in the bad state.

--- a/.claude/skills/zephyr-debugging/references/native_sim.md
+++ b/.claude/skills/zephyr-debugging/references/native_sim.md
@@ -16,7 +16,7 @@ simulates those. Use it for the firmware's logic, not its hardware coupling.
 ## Build & run
 
 ```
-uv run west build -b native_sim -p always -d builds/<app> applications/<app>
+mise x -- west build -b native_sim -p always -d builds/<app> applications/<app>
 ./build/<app>/zephyr/zephyr.exe            # runs as a normal process
 ./build/<app>/zephyr/zephyr.exe --help     # native_sim runtime options
 ```
@@ -41,7 +41,7 @@ watchpoints on a Cortex-M.
 ## Sanitizers — the reason to bother
 
 ```
-uv run west build -b native_sim -d builds/<app> applications/<app> -- \
+mise x -- west build -b native_sim -d builds/<app> applications/<app> -- \
     -DCONFIG_ASAN=y -DCONFIG_UBSAN=y
 ./build/<app>/zephyr/zephyr.exe
 ```
@@ -56,10 +56,10 @@ uv run west build -b native_sim -d builds/<app> applications/<app> -- \
 
 ```
 # coverage: which lines a test/run actually exercised
-uv run west build -b native_sim ... -- -DCONFIG_COVERAGE=y
+mise x -- west build -b native_sim ... -- -DCONFIG_COVERAGE=y
 ./zephyr.exe && gcovr -r .            # or lcov/genhtml
 # twister runs this for you:
-uv run west twister -T tests --coverage -p native_sim
+mise x -- west twister -T tests --coverage -p native_sim
 
 # rr — record once, replay deterministically backwards/forwards
 rr record ./build/<app>/zephyr/zephyr.exe

--- a/.claude/skills/zephyr-debugging/references/pyserial-howto.md
+++ b/.claude/skills/zephyr-debugging/references/pyserial-howto.md
@@ -111,15 +111,15 @@ log lines. Save raw, then narrow.
 ## Project venv
 
 `import serial` only works inside the project venv. If
-`uv run python3 -c "import serial"` fails with `ModuleNotFoundError`,
+`mise x -- python3 -c "import serial"` fails with `ModuleNotFoundError`,
 you're invoking python from outside the project root:
 
 ```bash
 cd /path/to/project        # IMPORTANT
-uv run python3 ...
+mise x -- python3 ...
 ```
 
-`uv run west <command>` has the same constraint — west extensions, the
+`mise x -- west <command>` has the same constraint — west extensions, the
 build, and any pyserial use all rely on the same `.venv/`.
 
 ## Debug build overlays
@@ -142,7 +142,5 @@ CONFIG_I2C_LOG_LEVEL_DBG=y
 Build with:
 
 ```bash
-uv run west build ... --extra-conf debug.conf
-# or via poe if the project supports it:
-uv run poe agent-build-app --debug
+mise x -- west build ... --extra-conf debug.conf
 ```

--- a/.claude/skills/zephyr-debugging/references/reset.md
+++ b/.claude/skills/zephyr-debugging/references/reset.md
@@ -6,13 +6,13 @@ inversely (so default to the *last* one if you're not sure).
 
 ## Reflash to reset (most reliable, ~9 s)
 
-`west flash` (and any wrapper poe task that calls it) drives NRST as part
+`west flash` (and any wrapper mise task that calls it) drives NRST as part
 of programming. Start the serial reader in the background, kick off the
 flash, then collect the captured log. Cheap, deterministic, and gives you
 "booted with the image I think it has."
 
 ```bash
-uv run python3 -u <<'PY' > /tmp/serial.log 2>&1 &
+mise x -- python3 -u <<'PY' > /tmp/serial.log 2>&1 &
 import serial, time, re, sys
 strip = lambda b: re.sub(r'\x1b\[[0-9;=?]*[mABCDEFGHJKLMST]', '',
                           b.decode('utf-8', errors='replace'))
@@ -25,14 +25,14 @@ while time.time() < deadline:
         sys.stdout.write(strip(data)); sys.stdout.flush()
 PY
 sleep 1
-uv run poe flash --proj <app>     # or: uv run west flash -r openocd
+mise run flash <app>            # or: mise x -- west flash -r openocd
 wait
 cat /tmp/serial.log
 ```
 
 The default `west flash` runner is whatever was resolved at configure
 time; on STM32 workspaces that often means `stm32cubeprogrammer` (rarely
-installed). Pass `-r openocd` explicitly or use the project's poe task,
+installed). Pass `-r openocd` explicitly or use the project's mise task,
 which usually pins openocd.
 
 ## openocd reset (no reflash, ~3 s)

--- a/.claude/skills/zephyr-debugging/references/serial.md
+++ b/.claude/skills/zephyr-debugging/references/serial.md
@@ -10,7 +10,7 @@ debug probe is attached, `rtt.md` gives you the same logs over SWD.
 You have Python + `pyserial`. Open the device (default `/dev/ttyACM0`),
 talk to the shell whose prompt is `uart:~$`. Pattern: drain stale data,
 write a command + `\r`, read back the response, strip ANSI before matching.
-**Run python inside the project venv** — `uv run python3 ...` from the
+**Run python inside the project venv** — `mise x -- python3 ...` from the
 project root or pyserial won't import.
 
 ```python

--- a/.claude/skills/zephyr-kernel/SKILL.md
+++ b/.claude/skills/zephyr-kernel/SKILL.md
@@ -16,7 +16,7 @@ description: >
 
 # Zephyr Kernel
 
-Validated against: Zephyr 4.4.99 (b3e7c445b343, 2026-07-26). Re-check with `uv run poe check-skills`.
+Validated against: Zephyr 4.4.99 (a632b9723bab, 2026-08-07). Re-check with `mise run check-skills`.
 
 ## Scope
 

--- a/.claude/skills/zephyr-peripherals/SKILL.md
+++ b/.claude/skills/zephyr-peripherals/SKILL.md
@@ -19,7 +19,7 @@ description: >
 
 # Zephyr Peripherals
 
-Validated against: Zephyr 4.4.99 (b3e7c445b343, 2026-07-26). Re-check with `uv run poe check-skills`.
+Validated against: Zephyr 4.4.99 (a632b9723bab, 2026-08-07). Re-check with `mise run check-skills`.
 
 ## Scope
 

--- a/.claude/skills/zephyr-peripherals/references/lvgl.md
+++ b/.claude/skills/zephyr-peripherals/references/lvgl.md
@@ -438,7 +438,7 @@ device that LVGL flushes into.)
 #### Building
 
 ```bash
-uv run west build -b native_sim/native/64 -p always \
+mise x -- west build -b native_sim/native/64 -p always \
                   -d builds/<app>_sim applications/<app>
 ./build/<app>_sim/zephyr/zephyr.exe
 ```
@@ -447,14 +447,16 @@ uv run west build -b native_sim/native/64 -p always \
 flavors; use `-p always` whenever you change configs to force a clean
 configure.)
 
-If your project uses `poe` tasks, add a sim variant alongside the
+If your project uses `mise` tasks, add a sim variant alongside the
 hardware build:
 
 ```toml
 [tasks.build-sim]
-cmd  = "west build -b native_sim/native/64 -p always -d builds/${proj}_sim applications/${proj}"
-[tasks.build-sim.args]
-proj = { default = "beta_hri" }
+description = "Build an application for native_sim."
+usage = '''
+arg "<app>" help="App name"
+'''
+run = "west build -b native_sim/native/64 -p always --build-dir builds/${usage_app}_sim applications/${usage_app}"
 ```
 
 The `zephyr.exe` is a normal POSIX binary — run it directly, kill it
@@ -502,7 +504,7 @@ For pure UI work the loop is:
 
 ```bash
 # Edit ui_screen_foo.c
-uv run west build -d builds/foo_sim
+mise x -- west build -d builds/foo_sim
 ./build/foo_sim/zephyr/zephyr.exe
 ```
 

--- a/.claude/skills/zephyr-serialization/SKILL.md
+++ b/.claude/skills/zephyr-serialization/SKILL.md
@@ -15,7 +15,7 @@ description: >
 
 # Zephyr Serialization
 
-Validated against: Zephyr 4.4.99 (b3e7c445b343, 2026-07-26). Re-check with `uv run poe check-skills`.
+Validated against: Zephyr 4.4.99 (a632b9723bab, 2026-08-07). Re-check with `mise run check-skills`.
 
 ## Scope
 
@@ -41,7 +41,7 @@ carry these payloads (CoAP/HTTP/MQTT/SMP) — see `zephyr-connectivity`.
 
 ⚠️ **nanopb is not in this workspace's `west.yml` allowlist**, so
 `deps/modules/lib/nanopb` does not exist and no app here uses protobuf. Adding
-the module is a one-line `west.yml` change plus `poe west-update` — see the note
+the module is a one-line `west.yml` change plus `mise run west-update` — see the note
 at the top of `references/protobuf.md`. Its `CONFIG_NANOPB*` symbols are
 consequently unverified.
 

--- a/.claude/skills/zephyr-serialization/references/protobuf.md
+++ b/.claude/skills/zephyr-serialization/references/protobuf.md
@@ -18,14 +18,14 @@
 > ```
 >
 > ```bash
-> uv run poe west-update
+> mise run west-update
 > ```
 >
 > You also need the host `protoc` compiler available — nanopb's CMake
 > integration invokes it at build time.
 >
 > Because the module is absent, the `CONFIG_NANOPB*` symbols below are
-> **unverified against the tree** — `uv run poe check-skills` allowlists them
+> **unverified against the tree** — `mise run check-skills` allowlists them
 > for that reason rather than confirming them. Re-check them once the module is
 > actually cloned. Everything in `./cbor.md` and `./json.md` *is* verified;
 > prefer CBOR unless you specifically need protobuf schema compatibility with

--- a/.claude/skills/zephyr-system/SKILL.md
+++ b/.claude/skills/zephyr-system/SKILL.md
@@ -23,7 +23,7 @@ description: >
 
 # Zephyr System
 
-Validated against: Zephyr 4.4.99 (b3e7c445b343, 2026-07-26). Re-check with `uv run poe check-skills`.
+Validated against: Zephyr 4.4.99 (a632b9723bab, 2026-08-07). Re-check with `mise run check-skills`.
 
 ## Scope
 

--- a/.claude/skills/zephyr-system/references/kconfig.md
+++ b/.claude/skills/zephyr-system/references/kconfig.md
@@ -144,7 +144,7 @@ the merged config rather than trusting `prj.conf`:
 grep FOO builds/<app>/zephyr/.config
 ```
 
-For the skill references in this repo, `uv run poe check-skills` validates every
+For the skill references in this repo, `mise run check-skills` validates every
 cited `CONFIG_*` against the current tree for exactly this reason.
 
 #### `CONFIG_*` in `prj.conf` never configures another image

--- a/.claude/skills/zephyr-system/references/storage.md
+++ b/.claude/skills/zephyr-system/references/storage.md
@@ -1202,7 +1202,7 @@ if (free < MINIMUM_REQUIRED) {
 
 #### Reflashing does NOT clear the storage partition
 
-**`west flash` / `poe flash` only erases the image region.** On ESP32 targets
+**`west flash` / `mise run flash` only erases the image region.** On ESP32 targets
 esptool writes just the app slot (e.g. `0x20000–0x105fff`), so whatever was in
 the ZMS/settings/storage partition survives — across a rebuild, across a
 different app, across a Zephyr version bump.
@@ -1221,8 +1221,8 @@ Consequences seen on hardware in this workspace:
 Full chip erase is the recovery:
 
 ```bash
-uv run esptool --port /dev/cu.usbmodem1101 erase-flash
-uv run poe flash <app>
+mise x -- esptool --port /dev/cu.usbmodem1101 erase-flash
+mise run flash <app>
 ```
 
 Two caveats:

--- a/.claude/skills/zephyr-system/references/sysbuild-mcuboot.md
+++ b/.claude/skills/zephyr-system/references/sysbuild-mcuboot.md
@@ -9,7 +9,7 @@ In this workspace, six apps opt in via a `sysbuild.conf`:
 `pt_mcp`, `rasprover`. Build them with:
 
 ```bash
-uv run poe app rasprover --sysbuild
+mise run app rasprover --sysbuild
 ```
 
 ## Contents
@@ -95,7 +95,7 @@ CONFIG_LOG=y
 or pass it inline:
 
 ```bash
-uv run west build --sysbuild -b <board> --build-dir builds/<app> applications/<app> \
+mise x -- west build --sysbuild -b <board> --build-dir builds/<app> applications/<app> \
     -- -Dmcuboot_CONFIG_BOOT_MAX_IMG_SECTORS=256
 ```
 
@@ -228,7 +228,7 @@ Enable the MCUboot-side Kconfig for whichever transport does the upload —
 
 - **`west flash` after a sysbuild build must flash `merged.hex`.** Flashing the
   app alone gives an unsigned image in slot 0 and a device that hangs in the
-  bootloader. `uv run poe flash <app>` uses the build directory, so make sure it
+  bootloader. `mise run flash <app>` uses the build directory, so make sure it
   was a `--sysbuild` build if that's what you intend.
 - **Artifact paths gain a domain level.** `builds/<app>/<app>/zephyr/zephyr.elf`,
   not `builds/<app>/zephyr/zephyr.elf`. Stale debugger paths read the wrong ELF
@@ -253,6 +253,6 @@ Enable the MCUboot-side Kconfig for whichever transport does the upload —
   file are silently ignored — see `./kconfig.md`.
 - **Erasing flash wipes your bootloader too.** A full `esptool erase-flash` or
   `nrfjprog --eraseall` removes MCUboot; reflash `merged.hex`, not just the app.
-  Note that on ESP32 targets a plain `poe flash` only erases the app region, so
+  Note that on ESP32 targets a plain `mise run flash` only erases the app region, so
   stale ZMS/settings data can survive and wedge the firmware — see
   `./storage.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,12 @@ mise run check-skills     # after west-update: flag Zephyr API drift in .claude/
 **Run `check-skills` after every `west-update`.** It validates every `CONFIG_*`
 symbol cited in `.claude/skills/` against the Kconfig tree in `deps/`, and warns
 when a skill's `Validated against:` stamp no longer matches the Zephyr checkout.
-Renamed or removed Kconfig symbols are silently ignored by `prj.conf`, so stale
-skill docs otherwise produce builds that look fine but have the feature off.
+Assigning a renamed or removed symbol in a handwritten fragment (`prj.conf`,
+`boards/*.conf`, `--extra-conf`) aborts the Kconfig stage outright —
+`scripts/kconfig/kconfig.py` sets `warn_assign_undef` for handwritten input and
+then turns the warning into `error: Aborting due to Kconfig warnings`. A stale
+skill therefore sends you into a build failure whose real cause is a doc, not
+your code.
 It is deliberately *not* part of `west-update` — doc drift should not fail a
 dependency update. Deeper API drift (function signatures, removed C APIs) is not
 covered and still needs a manual pass over `doc/releases/migration-guide-*.rst`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,14 +75,14 @@ The west.yml uses `name-allowlist` to clone only the modules these apps need; do
 - `boards/<vendor>/<board>/` — out-of-tree board definitions.
 - `deps/zephyr/` — Zephyr tree (managed by west, gitignored).
 - `deps/modules/lib/rosterloh-drivers/` — out-of-tree drivers repo. Tracks `main` via west.yml. Local edits during PR development are fine; commit them in that repo, not this one.
-- `deps/modules/lib/zenoh/` — zenoh-pico, patched by `poe patch-zenoh`.
+- `deps/modules/lib/zenoh/` — zenoh-pico, patched by `mise run patch-zenoh`.
 - `builds/<app>/` — build outputs (gitignored).
 - `logs/` — `agent-build` log destination.
 
 ## Formatting
 
-- Python: `uv run poe fmt` (ruff format, line-length 120).
-- C / Zephyr code: clang-format using the in-tree `.clang-format`. Verify with `uv run clang-format --dry-run --Werror <files>`.
+- Python: `mise run fmt` (ruff format, line-length 120).
+- C / Zephyr code: clang-format using the in-tree `.clang-format`. Verify with `mise x -- clang-format --dry-run --Werror <files>`.
 
 ## Out-of-tree modules and PR work
 
@@ -90,8 +90,8 @@ When iterating on `deps/modules/lib/rosterloh-drivers` (or zenoh) you are editin
 
 1. Branch and commit inside the module dir.
 2. Push and open a PR against that module's repo (e.g. `rosterloh/zephyr-drivers`).
-3. Verify dependent apps still build from this workspace: `uv run poe build-motor`, etc.
-4. After merge: `uv run poe west-update` to advance the pinned `main` ref locally.
+3. Verify dependent apps still build from this workspace: `mise run app motor_controller`, etc.
+4. After merge: `mise run west-update` to advance the pinned `main` ref locally.
 
 Do **not** vendor module changes into this repo; west owns those paths.
 

--- a/scripts/check_skill_symbols.py
+++ b/scripts/check_skill_symbols.py
@@ -2,9 +2,11 @@
 """Validate that every CONFIG_* symbol cited in .claude/skills/ exists in deps/.
 
 The Zephyr skill references are large hand/LLM-authored documents. The failure
-mode that matters is a Kconfig symbol that was renamed or removed upstream:
-`prj.conf` silently ignores unknown symbols, so a stale skill produces a build
-that "works" but doesn't have the feature enabled.
+mode that matters is a Kconfig symbol that was renamed or removed upstream.
+Zephyr sets `warn_assign_undef` for handwritten fragments and turns that warning
+into an error, so a stale symbol in `prj.conf` does not quietly do nothing -- it
+aborts the build at the Kconfig stage with "Aborting due to Kconfig warnings",
+pointing at your config rather than at the skill that told you to write it.
 
 This scans skill markdown for CONFIG_* tokens and checks each against the
 symbol universe defined by the Kconfig files under deps/. It also compares the

--- a/scripts/check_skill_symbols.py
+++ b/scripts/check_skill_symbols.py
@@ -144,7 +144,7 @@ def main() -> int:
     args = ap.parse_args()
 
     if not ZEPHYR.exists():
-        print("deps/zephyr missing -- run: uv run poe west-update", file=sys.stderr)
+        print("deps/zephyr missing -- run: mise run west-update", file=sys.stderr)
         return 2
 
     universe = kconfig_universe()


### PR DESCRIPTION
Ran `check-skills` against a freshly updated `deps/` tree and fixed the drift it surfaced, plus a documentation error the run exposed.

## check-skills result

```
Zephyr tree:  4.4.99 (a632b9723bab)
Kconfig defs: 25384 symbols under deps/
Skills cite:  753 distinct CONFIG_* symbols
Allowlisted:  53

All cited CONFIG_* symbols resolve against the current tree.
```

All 753 cited symbols resolve; no renames, no removals. The only complaint on the first run was the six stale `Validated against:` stamps — the tree had moved 1327 commits from `b3e7c445b343` (2026-07-26) to `a632b9723bab`. Refreshed.

## Manual API-drift pass

`check-skills` only covers `CONFIG_*`, so I read the `migration-guide-4.5` delta over those 1327 commits — 14 new entries. None affect the skills or this repo's code. Two were worth checking properly rather than by inspection:

- **rpi_pico `vreg` now `disabled` by default** — relevant since `pico_fw` targets `rpi_pico/rp2040/w`, but no board or overlay here references the node.
- **`st,stm32-usbphyc` now requires `clock-names`** — `nucleo_h7s3l8` and `stm32h7s78_dk` both use `&usbphyc`, but they only set `status = "okay"` and inherit `gate`/`mux`/`fsel` from the h7rs SoC dtsi, so no board override is needed.

The rest (`sys_clock.h` deprecation, `CONFIG_BUILD_WITH_TFM` no longer implying MBEDTLS/PSA_CRYPTO, hwspinlock ctx removal, `bt_bap_stream_ops` renames, NXP mux/inputmux and MPU changes) is neither cited by the skills nor used here.

## Finishing the mise migration

#61 swapped poethepoet for mise but didn't propagate to the docs, leaving 17 files documenting commands that no longer exist. Beyond the mechanical rename, several were wrong in substance:

- `flash` took `--proj <app>`; the mise task takes a bare app name.
- `agent-build-app --debug` didn't survive the migration at all — no such task, no such flag. That snippet now just shows the `west build` with `--extra-conf`.
- `lvgl.md`'s sample sim task used poe `[tasks.*.args]` syntax; rewritten as a mise `usage`/`run` task.
- `AGENTS.md` pointed at `build-motor`, which was never a mise task.

Also converted `uv run <tool>` to `mise x -- <tool>`, the ad-hoc form `AGENTS.md` names. Those commands still worked, they were just off-idiom — happy to drop that part if you'd rather keep the diff tight.

The `poethepoet` skill is deliberately untouched; it documents poe itself, not this workspace.

## Correcting the stated failure mode for stale symbols

`AGENTS.md` and the `check_skill_symbols.py` docstring both claimed renamed or removed symbols are *"silently ignored by `prj.conf`"*, producing a build that looks fine with the feature off. That is backwards.

`scripts/kconfig/kconfig.py` sets `warn_assign_undef` for handwritten input fragments, then escalates any warning that isn't "set more than once" into `err("Aborting due to Kconfig warnings")`. Verified by building `powerbread` for `native_sim/native/64` with an `--extra-conf` assigning an undefined symbol:

```
bogus.conf:1: warning: attempt to assign the value 'y' to the undefined symbol HAWKBIT_DEFINITELY_NOT_A_REAL_SYMBOL
error: Aborting due to Kconfig warnings
CMake Error at .../cmake/modules/kconfig.cmake:427 (message):
  command failed with return code: 1
```

So a stale skill doesn't silently misconfigure a build, it breaks it, and the error points at your config rather than the doc that told you to write it. This strengthens the case for running `check-skills` after `west-update` rather than weakening it.

## Verification

- `check-skills` passes clean (exit 0) on the final tree.
- No functional code changed — docs, skill references, and one script docstring only.

## Note on the environment

`mise` isn't installed in the container I ran this in, and the proxy blocks both `mise.run` and GitHub release downloads, so I drove the underlying commands through `uv` directly (`uv sync`, `uv run west update --narrow`, `uv run python scripts/check_skill_symbols.py`) — the same venv `mise x --` activates. I could not exercise the `mise run` task wrappers themselves, so the corrected task names above are verified by reading `mise.toml`, not by running them. Worth a sanity check from someone with mise on PATH.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuwhW4QBz92iRh5yvKFSGA)_