### PR TITLE
data_collection: use the workspace's forked IMX219 driver

### DIFF
--- a/applications/data_collection/prj.conf
+++ b/applications/data_collection/prj.conf
@@ -23,6 +23,12 @@ CONFIG_NET_CONFIG_NEED_IPV4=y
 # (SMH attribute 2 = external) and aligned to the 64-byte D-cache line.
 CONFIG_VIDEO=y
 CONFIG_VIDEO_ESP32_CSI=y
+# Use the workspace's forked IMX219 driver, not Zephyr's in-tree one: the
+# in-tree PLL table makes the sensor transmit at ~400 Mbps/lane while
+# advertising a 456 MHz (912 Mbps) link frequency. Both bind "sony,imx219", so
+# the in-tree one must be turned off explicitly.
+CONFIG_VIDEO_IMX219=n
+CONFIG_VIDEO_IMX219_OOT=y
 CONFIG_VIDEO_SHELL=y
 CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=2
 CONFIG_VIDEO_BUFFER_POOL_ALIGN=64


### PR DESCRIPTION
> **Blocked on rosterloh/zephyr-drivers#30.** `CONFIG_VIDEO_IMX219_OOT` does not exist on the module's `main` yet, so CI cannot pass until that PR merges and `west.yml`'s pin advances (`mise run west-update`). Marked draft until then.

Zephyr's in-tree `imx219` driver programs the sensor for ~400 Mbps/lane (`PLL_OP_MPY = 50`, `PREPLLCK_OP_DIV = 3`, `OPSYCK_DIV = 1`, i.e. 24/3*50) while advertising `VIDEO_CID_LINK_FREQ` = 456 MHz, which is 912 Mbps/lane. This app's CSI receiver has nothing but the advertised value to configure its D-PHY from, so it selects the wrong `hs_freq_sel` frequency range.

Switch to the corrected fork in `rosterloh-drivers`, which uses Raspberry Pi's kernel values (`PLL_OP_MPY` 114, `PLL_VT_MPY` 57, `VTPXCK_DIV` 5). Verified on hardware by reading the sensor back over I2C: `PLL_OP_MPY` = 0x0072 after the change.

Both drivers bind `sony,imx219`, and the in-tree Kconfig defaults to `y` whenever the devicetree node is present, so it has to be disabled explicitly or the same device gets defined twice.

Upstream bug: zephyrproject-rtos/zephyr#116178. **If that is fixed upstream, revert this and drop the fork** rather than carrying it.

### Caveat

This does not make the camera capture. The PLL was genuinely misconfigured and is now correct, but capture still fails for a separate, unresolved reason — the receiver's D-PHY reports no lane activity at all while the sensor is verified to be in streaming mode. See rosterloh/zephyr-drivers#30 for the full investigation and what it rules out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)