### PR TITLE
rasprover: add hardware-backed task watchdog

### DIFF
--- a/applications/rasprover/CMakeLists.txt
+++ b/applications/rasprover/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources_ifdef(CONFIG_APP_ZENOH  app PRIVATE src/app_zenoh.c)
 target_sources_ifdef(CONFIG_APP_MOTORS app PRIVATE src/app_motors.c)
 target_sources_ifdef(CONFIG_APP_GIMBAL app PRIVATE src/app_gimbal.c)
 target_sources_ifdef(CONFIG_APP_TIME_SYNC app PRIVATE src/app_time.c)
+target_sources_ifdef(CONFIG_APP_WATCHDOG app PRIVATE src/app_watchdog.c)
 target_sources(app PRIVATE src/app_ros_cdr.c)
 
 # On Debian/Ubuntu, libsdl2-dev uses a multiarch include path that Zephyr's

--- a/applications/rasprover/Kconfig
+++ b/applications/rasprover/Kconfig
@@ -226,4 +226,21 @@ config APP_ZENOH_GIMBAL_CMD_KEY
 
 endif # APP_GIMBAL
 
+config APP_WATCHDOG
+	bool "Enable task watchdog stall detection"
+	default y
+	select TASK_WDT
+	select WATCHDOG
+	help
+	  Monitors main() with Zephyr's task watchdog and reboots the board if
+	  it stops being fed: first a "boot" channel covering the init sequence
+	  (where a WiFi connect can livelock), then a "main" channel covering
+	  the superloop. rasprover's observed failure modes are hangs rather
+	  than CPU faults, which a fatal-error handler cannot catch.
+
+	  Covers only what main() calls directly. A hang inside a workqueue
+	  handler (e.g. the LVGL display work submitted by app_display_init())
+	  or during pre-main driver init is not detected -- main keeps running
+	  and keeps feeding. Those need their own channel fed by that thread.
+
 source "Kconfig.zephyr"

--- a/applications/rasprover/src/app_watchdog.c
+++ b/applications/rasprover/src/app_watchdog.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Richard Osterloh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(app_watchdog, LOG_LEVEL_INF);
+
+#include <errno.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/task_wdt/task_wdt.h>
+
+#include "app_watchdog.h"
+
+/* ros_driver/esp32 aliases the TIMG0 MWDT as watchdog0, so the task watchdog
+ * is backed by real hardware via CONFIG_TASK_WDT_HW_FALLBACK: the kernel timer
+ * catches a stalled task, the hardware resets the SoC if the kernel itself
+ * hangs. Targets without a watchdog0 alias (native_sim) pass NULL to
+ * task_wdt_init(), which is the documented software-only fallback — stall
+ * detection still works, but nothing catches a wedged kernel. */
+#if DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay)
+#define APP_WDT_HW_DEV DEVICE_DT_GET(DT_ALIAS(watchdog0))
+#else
+#define APP_WDT_HW_DEV NULL
+#endif
+
+static bool wdt_ready;
+
+static void wdt_timeout_cb(int channel_id, void *user_data)
+{
+	/* Synchronous logging so this reaches the console before the reset. */
+	LOG_PANIC();
+	LOG_ERR("Task watchdog timeout: '%s' (channel %d) stalled - rebooting",
+		(const char *)user_data, channel_id);
+
+	sys_reboot(SYS_REBOOT_COLD);
+}
+
+int app_watchdog_init(void)
+{
+	const struct device *hw_wdt = APP_WDT_HW_DEV;
+	int ret;
+
+	if (hw_wdt != NULL && !device_is_ready(hw_wdt)) {
+		LOG_WRN("Hardware watchdog not ready; falling back to software only");
+		hw_wdt = NULL;
+	}
+
+	ret = task_wdt_init(hw_wdt);
+	if (ret != 0) {
+		/* Deliberately loud: everything below degrades to a no-op from
+		 * here, so the board boots and runs with no stall detection at
+		 * all. That is the one failure this module must not report
+		 * quietly. */
+		LOG_ERR("*** task_wdt_init failed (%d) ***", ret);
+		LOG_ERR("*** RUNNING UNPROTECTED: no stall detection, hangs will not reboot ***");
+		return ret;
+	}
+
+	wdt_ready = true;
+	LOG_INF("Task watchdog initialised (hardware backing: %s)", hw_wdt ? "yes" : "no");
+
+	return 0;
+}
+
+int app_watchdog_register(const char *name, uint32_t timeout_ms)
+{
+	int ch;
+
+	if (!wdt_ready) {
+		return -EBUSY;
+	}
+
+	ch = task_wdt_add(timeout_ms, wdt_timeout_cb, (void *)name);
+	if (ch < 0) {
+		LOG_ERR("task_wdt_add('%s') failed (%d)", name, ch);
+	} else {
+		LOG_INF("Watchdog channel %d registered for '%s' (%u ms)", ch, name, timeout_ms);
+	}
+
+	return ch;
+}
+
+void app_watchdog_unregister(int channel)
+{
+	if (wdt_ready && channel >= 0) {
+		task_wdt_delete(channel);
+	}
+}
+
+void app_watchdog_feed(int channel)
+{
+	if (wdt_ready && channel >= 0) {
+		task_wdt_feed(channel);
+	}
+}

--- a/applications/rasprover/src/app_watchdog.h
+++ b/applications/rasprover/src/app_watchdog.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Richard Osterloh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Stall detection on top of Zephyr's task watchdog. rasprover's observed
+ * failure modes are hangs (display init, WiFi connect) rather than CPU
+ * faults, and a fatal-error handler catches neither. A monitored task
+ * registers a channel and feeds it from its loop; if it stops feeding, the
+ * stall is logged and the board cold-reboots. Where a hardware watchdog is
+ * available it also resets the SoC if the kernel itself hangs.
+ *
+ * Coverage is per registered thread, and main() is the only registrant, so
+ * only hangs in main's own call path are detected -- app_net_connect() among
+ * them. A hang inside a workqueue handler (the LVGL display work, which
+ * app_display_init() only submits) leaves main running and feeding, and a
+ * pre-main driver init hang predates the first feed. Catching either needs a
+ * channel registered and fed by that thread.
+ */
+
+#ifndef APP_WATCHDOG_H
+#define APP_WATCHDOG_H
+
+#include <errno.h>
+#include <stdint.h>
+#include <zephyr/toolchain.h>
+
+#ifdef CONFIG_APP_WATCHDOG
+
+/* Initialise the task watchdog. Call once, as early in main() as possible:
+ * the boot sequence itself is what needs covering. Returns 0 on success,
+ * negative on error, in which case register/feed degrade to no-ops. */
+int app_watchdog_init(void);
+
+/* Register a monitored task. Returns a channel id (>= 0), or negative if the
+ * watchdog is unavailable or not initialised yet — callers may treat that as
+ * "not registered" and retry. `name` must be a long-lived string (it is used
+ * in the timeout log). */
+int app_watchdog_register(const char *name, uint32_t timeout_ms);
+
+/* Stop monitoring a channel, e.g. when a boot-phase channel is replaced by a
+ * steady-state one. No-op for a negative channel or before init. */
+void app_watchdog_unregister(int channel);
+
+/* Feed a registered channel. No-op for a negative channel or before init. */
+void app_watchdog_feed(int channel);
+
+#else /* Not built: degrade to no-ops so call sites stay unguarded. */
+
+static inline int app_watchdog_init(void)
+{
+	return -ENOTSUP;
+}
+
+static inline int app_watchdog_register(const char *name, uint32_t timeout_ms)
+{
+	ARG_UNUSED(name);
+	ARG_UNUSED(timeout_ms);
+	return -ENOTSUP;
+}
+
+static inline void app_watchdog_unregister(int channel)
+{
+	ARG_UNUSED(channel);
+}
+
+static inline void app_watchdog_feed(int channel)
+{
+	ARG_UNUSED(channel);
+}
+
+#endif /* CONFIG_APP_WATCHDOG */
+
+#endif /* APP_WATCHDOG_H */

--- a/applications/rasprover/src/main.c
+++ b/applications/rasprover/src/main.c
@@ -8,6 +8,7 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 #include "app_sensors.h"
 #include "app_settings.h"
 #include "app_time.h"
+#include "app_watchdog.h"
 #include "app_zenoh.h"
 #include <zephyr/kernel.h>
 
@@ -24,6 +25,20 @@ int main(void)
 
 	_system_thread = k_current_get();
 
+	/* Cover the init sequence, not just the superloop: the hangs this
+	 * watchdog exists for happen during boot, inside app_net_connect().
+	 *
+	 * Sized off the longest legitimate *single* step rather than the total,
+	 * because the channel is fed between steps. That step is
+	 * app_net_connect(), bounded at NET_CONNECT_TIMEOUT (30 s) by its
+	 * k_sem_take(). Everything else is either non-blocking (app_time_start()
+	 * and app_display_init() only submit work) or bounded well under it
+	 * (z_open() by APP_ZENOH_TRANSPORT_CONNECT_TIMEOUT_MS, 10 s; the locator
+	 * is an IP literal, so no DNS resolve). 60 s is 2x that worst step,
+	 * leaving room for a driver that overruns its own bound. */
+	app_watchdog_init();
+	int wdt_channel = app_watchdog_register("boot", 60000);
+
 	app_sensors_init();
 #ifdef CONFIG_APP_MOTORS
 	app_motors_init();
@@ -31,19 +46,38 @@ int main(void)
 #ifdef CONFIG_APP_GIMBAL
 	app_gimbal_init();
 #endif
+
+	app_watchdog_feed(wdt_channel);
 	app_net_connect();
 	if (app_net_ipv4_ready()) {
+		app_watchdog_feed(wdt_channel);
 		app_time_start();
 		app_zenoh_init();
 	} else {
 		LOG_WRN("Network unavailable; skipping time sync and zenoh");
 	}
 
+	app_watchdog_feed(wdt_channel);
 #ifdef CONFIG_APP_DISPLAY
 	app_display_init();
 #endif
 
+	/* Boot done: swap the boot channel for the steady-state one. Its timeout
+	 * is derived from the loop delay rather than hardcoded, so it can't
+	 * silently break when that setting changes. One registration is enough
+	 * because the only writer of the delay is settings_load(), which runs
+	 * from SYS_INIT at APPLICATION level — i.e. before main() — so it cannot
+	 * change while the loop runs.
+	 * ponytail: single registration; if a runtime setter for the loop delay
+	 * is ever added, re-register (unregister + register) when it changes.
+	 *
+	 * 3x the loop period plus 10 s of headroom tolerates a slow sensor read
+	 * or a blocked zenoh publish while still catching a real stall. */
+	app_watchdog_unregister(wdt_channel);
+	wdt_channel = app_watchdog_register("main", get_loop_delay_s() * 3000 + 10000);
+
 	while (true) {
+		app_watchdog_feed(wdt_channel);
 		app_sensors_read_and_stream();
 
 		k_sleep(K_SECONDS(get_loop_delay_s()));


### PR DESCRIPTION
Adds stall detection to `rasprover`, ported from the pattern in [Protocentral/healthypi-move-fw](https://github.com/Protocentral/healthypi-move-fw). No app in this workspace had a watchdog before this.

## Why a watchdog, not a fatal handler

rasprover's recorded failure modes are **hangs, not CPU faults** — a WiFi boot auto-connect that livelocks the driver, and an LVGL mono display path that hangs on the ESP32 OLED. `k_sys_fatal_error_handler` catches neither. A fed watchdog catches a hang in main's own call path.

## What it does

`app_watchdog` wraps Zephyr's `task_wdt` in four functions (`init` / `register` / `unregister` / `feed`) that degrade to no-op `static inline`s when `CONFIG_APP_WATCHDOG=n`, so call sites carry no `#ifdef`s.

Coverage starts at the **top** of `main()`, not after init, because the init sequence is where the motivating hangs occur:

- **`"boot"` channel, 60 s** — covers the init sequence, fed between steps. Sized off the longest legitimate *single* step rather than the total: `app_net_connect()` at `NET_CONNECT_TIMEOUT` (30 s), doubled for a driver that overruns its own bound. Everything else is either non-blocking (`app_time_start()` and `app_display_init()` only submit work) or bounded well under it (`z_open()` at 10 s, IP-literal locator so no DNS leg).
- **`"main"` channel** — swapped in once boot completes; timeout derived from `get_loop_delay_s()` (3x the loop period + 10 s) rather than hardcoded, so it cannot silently break if that setting changes.

On `ros_driver/esp32` the TIMG0 MWDT is exposed as the `watchdog0` alias, so `CONFIG_TASK_WDT_HW_FALLBACK` backs the kernel timer with real hardware. Targets without that alias pass `NULL` to `task_wdt_init()` and get the documented software-only path.

## Known coverage limits

Documented in the header and Kconfig help rather than papered over. Coverage is **per registered thread**, and `main()` is the only registrant:

- A hang inside a workqueue handler — including the LVGL display work, which `app_display_init()` only *submits* — leaves `main` running and feeding, so it is **not** detected.
- A pre-`main()` driver init hang predates the first feed.

Catching either needs a channel registered and fed by that thread. The concrete win here is `app_net_connect()`.

## Notes

- A failed `task_wdt_init()` logs loudly (`*** RUNNING UNPROTECTED ***`) instead of silently leaving the board unprotected. Degrade-to-no-op behaviour retained.
- With HW fallback, `TASK_WDT_MIN_TIMEOUT` (100 ms) wakes a `k_timer` to feed the hardware WDT even while the app sleeps 60 s at a time. Harmless here; that symbol is the knob if power draw ever matters.
- No `__noinit` crash breadcrumb — deliberately descoped, since `.noinit` survival across the ESP32 second-stage bootloader is unverified.

## Verification

- `mise run agent-build rasprover --sysbuild` — **succeeds**, no new warnings.
- `native_sim` not re-run: fails at `arch/posix` CMake configure on macOS before compiling anything (known host limitation, unrelated). The Kconfig stage ahead of it resolves the new `select`s cleanly on a board with no watchdog device.
- **Not runtime-verified** — no hardware in this session. The reboot-on-stall path has never executed on a board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)