### PR TITLE
data_collection: add SMP camera management group

### DIFF
--- a/applications/data_collection/CMakeLists.txt
+++ b/applications/data_collection/CMakeLists.txt
@@ -14,3 +14,5 @@ project(data_collection)
 zephyr_compile_options(-fdiagnostics-color=always)
 
 target_sources(app PRIVATE src/main.c)
+
+target_sources_ifdef(CONFIG_APP_CAM_MGMT app PRIVATE src/cam_mgmt.c)

--- a/applications/data_collection/Kconfig
+++ b/applications/data_collection/Kconfig
@@ -1,0 +1,13 @@
+mainmenu "Application options"
+
+config APP_CAM_MGMT
+	bool "Camera SMP management group"
+	depends on MCUMGR && VIDEO
+	default y
+	help
+	  Register a custom MCUmgr group (id 0x1000) on the transports MCUmgr
+	  already serves, letting an SMP client query the camera, capture a
+	  frame and pull it back in chunks. Wire contract: see "SMP camera
+	  group" in the application README.
+
+source "Kconfig.zephyr"

--- a/applications/data_collection/README.md
+++ b/applications/data_collection/README.md
@@ -9,7 +9,7 @@ exposes an MCUmgr/SMP management surface over UDP, plus a UART shell.
 - **Ethernet** — on-chip RMII EMAC (`CONFIG_ETH_ESP32`) with DHCPv4 addressing.
   The assigned IPv4 address is logged once the lease is acquired.
 - **SMP over UDP** — MCUmgr OS group (remote reboot, echo, taskstat) reachable
-  with `mcumgr --conntype udp`.
+  with `mcumgr --conntype udp`, plus a custom camera group (below).
 - **Camera** — IMX219 (Raspberry Pi Camera v2) over MIPI CSI-2, via Zephyr's
   in-tree `raspberry_pi_camera_module_2` shield rather than a bespoke overlay.
   `CMakeLists.txt` sets `SHIELD` so no `--shield` argument is needed. Frames are
@@ -37,6 +37,43 @@ on-board USB-UART bridge on `uart0` (GPIO37/38), and the same port also carries
 the ROM log and the MCUboot log, so one serial connection shows the whole boot
 chain. The board's other USB connector is a USB-A **host** port (J2) and has no
 console role.
+
+## SMP camera group
+
+`src/cam_mgmt.c` registers a custom MCUmgr group so a host can drive the camera
+over the SMP transport already used for OTA, rather than only the boot-time
+capture and the interactive `video` shell. Enabled by `CONFIG_APP_CAM_MGMT`
+(default `y` when `MCUMGR` && `VIDEO`).
+
+**Group id `0x1000`.** Custom groups start at `MGMT_GROUP_ID_PERUSER` (64) and
+the Zephyr-specific groups count *down* from there, so `0x1000` keeps clear of
+both. Requests and responses are CBOR maps, as in every MCUmgr group.
+
+| cmd | name | op | request | response |
+|---|---|---|---|---|
+| 0 | `INFO` | read | — | `group` u32, `cam` tstr, `fmt` u32, `w` u16, `h` u16, `ready` bool |
+| 1 | `CAPTURE` | write | — | `seq` u32, `size` u32, `w` u16, `h` u16, `fmt` u32 |
+| 2 | `READ` | read | `seq` u32, `off` u32, `len` u16 | `seq` u32, `off` u32, `data` bstr, `eof` bool |
+
+- `group` is the command-set version (currently `1`), so clients need not be
+  pinned to a firmware build.
+- `fmt` is the Zephyr fourcc (`VIDEO_PIX_FMT_SBGGR10P`). `INFO`'s `fmt`/`w`/`h`
+  are what `CAPTURE` *requests*, not what the sensor negotiated — treat them as
+  planning values and **size buffers from `CAPTURE`'s `size`**, which is the
+  real frame length.
+- `CAPTURE` is a *write* because it drives the sensor and discards the
+  previously retained frame. `seq` starts at 1 and increments per capture.
+- `READ` pages the retained frame: repeat with `off += len(data)` until `eof`.
+  `len` is clamped to 1024 B, which fits both the response encode buffer
+  (`CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE`, 2048 B under UDP) and the datagram
+  (`CONFIG_MCUMGR_TRANSPORT_UDP_MTU`, 1500 B).
+- `READ` answers `MGMT_ERR_ENOENT` (3) if `seq` does not match the buffered
+  frame — nothing captured yet, or a newer `CAPTURE` replaced it mid-pull.
+  Restart from the `seq` that `CAPTURE` returned.
+
+Only one frame is buffered: it stays checked out of the video buffer pool (PSRAM,
+~2.5 MB per RAW10 frame) so `READ` serves it without a copy, and is released at
+the top of the next `CAPTURE`.
 
 ## OTA / MCUboot
 

--- a/applications/data_collection/src/cam_mgmt.c
+++ b/applications/data_collection/src/cam_mgmt.c
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026 Richard Osterloh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Custom MCUmgr (SMP) management group for the camera, so a host can drive
+ * capture over the same SMP/UDP transport this app already uses for OTA
+ * instead of only the boot-time capture and the interactive `video` shell.
+ * Commands: INFO (read) / CAPTURE (write) / READ (read).
+ * Wire contract: see "SMP camera group" in README.md.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/video.h>
+#include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
+#include <zephyr/mgmt/mcumgr/mgmt/handlers.h>
+#include <zephyr/mgmt/mcumgr/smp/smp.h>
+#include <zcbor_common.h>
+#include <zcbor_encode.h>
+#include <zcbor_decode.h>
+#include <mgmt/mcumgr/util/zcbor_bulk.h>
+
+#include "cam_mgmt.h"
+
+LOG_MODULE_REGISTER(cam_mgmt, LOG_LEVEL_INF);
+
+/* Vendor/custom group ids start at MGMT_GROUP_ID_PERUSER (64), and the
+ * Zephyr-specific groups count *down* from there, so anything comfortably above
+ * 64 is safe. 0x1000 keeps that distance and matches the convention used by
+ * other out-of-tree SMP groups. */
+#define CAM_MGMT_GROUP_ID      0x1000
+#define CAM_MGMT_GROUP_VERSION 1
+
+#define CAM_MGMT_CMD_INFO    0
+#define CAM_MGMT_CMD_CAPTURE 1
+#define CAM_MGMT_CMD_READ    2
+
+/* Largest chunk a single READ returns. The binding limit is the buffer the
+ * response is encoded into, CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE (2048 when
+ * MCUMGR_TRANSPORT_UDP is set, 384 otherwise); the datagram then has to fit
+ * CONFIG_MCUMGR_TRANSPORT_UDP_MTU (1500). 1024 plus the 8-byte SMP header and
+ * the CBOR map around the byte string lands near 1100 B, inside both, and is a
+ * round number for clients to page with. Raise it against NETBUF_SIZE *and*
+ * the MTU, not just one of them. */
+#define CAM_MGMT_READ_MAX 1024
+
+/* IMX219 2x2-binned full-FoV RAW10 frame. */
+#define CAPTURE_WIDTH  1640
+#define CAPTURE_HEIGHT 1232
+#define CAPTURE_FORMAT VIDEO_PIX_FMT_SBGGR10P
+#define CAPTURE_NBUFS  2
+
+/* Buffer ownership: the captured frame stays checked out of the video buffer
+ * pool until the next CAPTURE. A frame is ~2.5 MB of PSRAM, so READ serves it
+ * in place rather than copying it into a second buffer. The pool only holds
+ * CONFIG_VIDEO_BUFFER_POOL_NUM_MAX buffers and the CSI driver needs
+ * CAPTURE_NBUFS of them to stream, which is why the retained frame is released
+ * at the top of the next capture rather than kept alongside it. `frame_lock`
+ * stops a READ on the SMP thread from touching a buffer that the boot-time
+ * capture on the main thread is releasing. */
+static struct video_buffer *frame_vbuf;
+static uint32_t frame_seq;
+K_MUTEX_DEFINE(frame_lock);
+
+int cam_mgmt_capture(const struct device *cam)
+{
+	struct video_format fmt = {
+		.type = VIDEO_BUF_TYPE_OUTPUT,
+		.pixelformat = CAPTURE_FORMAT,
+		.width = CAPTURE_WIDTH,
+		.height = CAPTURE_HEIGHT,
+	};
+	struct video_buffer *vbuf = NULL;
+	struct video_buffer *drained;
+	int ret;
+
+	k_mutex_lock(&frame_lock, K_FOREVER);
+
+	if (frame_vbuf != NULL) {
+		video_buffer_release(frame_vbuf);
+		frame_vbuf = NULL;
+	}
+
+	ret = video_set_format(cam, &fmt);
+	if (ret < 0) {
+		LOG_ERR("Failed to set format (%d)", ret);
+		goto out;
+	}
+
+	ret = video_get_format(cam, &fmt);
+	if (ret < 0) {
+		goto out;
+	}
+	LOG_INF("Capturing %ux%u, pitch %u, %u bytes/frame", fmt.width, fmt.height, fmt.pitch,
+		fmt.pitch * fmt.height);
+
+	for (int i = 0; i < CAPTURE_NBUFS; i++) {
+		vbuf = video_buffer_aligned_alloc(fmt.pitch * fmt.height,
+						  CONFIG_VIDEO_BUFFER_POOL_ALIGN, K_NO_WAIT);
+		if (vbuf == NULL) {
+			LOG_ERR("Failed to allocate video buffer %d", i);
+			ret = -ENOMEM;
+			goto drain;
+		}
+		vbuf->type = VIDEO_BUF_TYPE_OUTPUT;
+		ret = video_enqueue(cam, vbuf);
+		if (ret < 0) {
+			LOG_ERR("Failed to enqueue buffer %d (%d)", i, ret);
+			video_buffer_release(vbuf);
+			goto drain;
+		}
+	}
+
+	ret = video_stream_start(cam, VIDEO_BUF_TYPE_OUTPUT);
+	if (ret < 0) {
+		LOG_ERR("Failed to start stream (%d)", ret);
+		goto drain;
+	}
+
+	ret = video_dequeue(cam, &vbuf, K_SECONDS(2));
+	if (ret < 0) {
+		LOG_ERR("Failed to dequeue frame (%d)", ret);
+		goto drain;
+	}
+
+	frame_vbuf = vbuf;
+	frame_seq++;
+	LOG_INF("Frame %u captured: %u bytes, first pixels %02x %02x %02x %02x", frame_seq,
+		vbuf->bytesused, vbuf->buffer[0], vbuf->buffer[1], vbuf->buffer[2],
+		vbuf->buffer[3]);
+
+drain:
+	/* video_stream_stop() cancels whatever is still queued into the done queue
+	 * (and does so even if the stream never started), so draining it here
+	 * covers both the success path and every failure above. Skip the retained
+	 * frame by identity: no driver should hand back a buffer we already
+	 * dequeued, but releasing it here would serve freed PSRAM to any SMP
+	 * client that asks, so don't depend on that. */
+	video_stream_stop(cam, VIDEO_BUF_TYPE_OUTPUT);
+	while (video_dequeue(cam, &drained, K_NO_WAIT) == 0) {
+		if (drained != frame_vbuf) {
+			video_buffer_release(drained);
+		}
+	}
+out:
+	k_mutex_unlock(&frame_lock);
+	return ret;
+}
+
+/* INFO (read): {} -> {group, cam, fmt, w, h, ready}. The format triple is what
+ * CAPTURE *requests*, not what the sensor negotiated -- video_set_format() may
+ * come back with something else. It is here so a client can plan before
+ * capturing anything; the authoritative frame length is CAPTURE's `size`, and
+ * clients must size their buffer from that. */
+static int cam_h_info(struct smp_streamer *ctxt)
+{
+	const struct device *cam = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
+	zcbor_state_t *zse = ctxt->writer->zs;
+	bool ok;
+
+	ok = zcbor_tstr_put_lit(zse, "group") && zcbor_uint32_put(zse, CAM_MGMT_GROUP_VERSION) &&
+	     zcbor_tstr_put_lit(zse, "cam") && zcbor_tstr_put_term(zse, cam->name, 32) &&
+	     zcbor_tstr_put_lit(zse, "fmt") && zcbor_uint32_put(zse, CAPTURE_FORMAT) &&
+	     zcbor_tstr_put_lit(zse, "w") && zcbor_uint32_put(zse, CAPTURE_WIDTH) &&
+	     zcbor_tstr_put_lit(zse, "h") && zcbor_uint32_put(zse, CAPTURE_HEIGHT) &&
+	     zcbor_tstr_put_lit(zse, "ready") && zcbor_bool_put(zse, device_is_ready(cam));
+
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
+}
+
+/* CAPTURE (write): {} -> {seq, size, w, h, fmt}. A write because it discards the
+ * previously retained frame and drives the sensor. */
+static int cam_h_capture(struct smp_streamer *ctxt)
+{
+	const struct device *cam = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
+	zcbor_state_t *zse = ctxt->writer->zs;
+	bool ok;
+
+	if (cam_mgmt_capture(cam) < 0) {
+		return MGMT_ERR_EUNKNOWN;
+	}
+
+	k_mutex_lock(&frame_lock, K_FOREVER);
+	/* cam_mgmt_capture() drops the lock before returning, so a capture on
+	 * another thread can have released our frame and then failed by the time we
+	 * get here. Report it gone rather than dereferencing NULL. */
+	if (frame_vbuf == NULL) {
+		k_mutex_unlock(&frame_lock);
+		return MGMT_ERR_ENOENT;
+	}
+
+	ok = zcbor_tstr_put_lit(zse, "seq") && zcbor_uint32_put(zse, frame_seq) &&
+	     zcbor_tstr_put_lit(zse, "size") && zcbor_uint32_put(zse, frame_vbuf->bytesused) &&
+	     zcbor_tstr_put_lit(zse, "w") && zcbor_uint32_put(zse, CAPTURE_WIDTH) &&
+	     zcbor_tstr_put_lit(zse, "h") && zcbor_uint32_put(zse, CAPTURE_HEIGHT) &&
+	     zcbor_tstr_put_lit(zse, "fmt") && zcbor_uint32_put(zse, CAPTURE_FORMAT);
+	k_mutex_unlock(&frame_lock);
+
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
+}
+
+/* READ (read): {seq, off, len} -> {seq, off, data, eof}. Cursor-paged pull of
+ * the retained frame; the client repeats with off += len(data) until eof. */
+static int cam_h_read(struct smp_streamer *ctxt)
+{
+	zcbor_state_t *zsd = ctxt->reader->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	uint32_t seq = 0, off = 0, want = CAM_MGMT_READ_MAX;
+	struct zcbor_string data;
+	size_t decoded;
+	bool ok, eof;
+	struct zcbor_map_decode_key_val dk[] = {
+		ZCBOR_MAP_DECODE_KEY_DECODER("seq", zcbor_uint32_decode, &seq),
+		ZCBOR_MAP_DECODE_KEY_DECODER("off", zcbor_uint32_decode, &off),
+		ZCBOR_MAP_DECODE_KEY_DECODER("len", zcbor_uint32_decode, &want),
+	};
+
+	if (zcbor_map_decode_bulk(zsd, dk, ARRAY_SIZE(dk), &decoded) != 0) {
+		return MGMT_ERR_EINVAL;
+	}
+
+	if (want == 0 || want > CAM_MGMT_READ_MAX) {
+		want = CAM_MGMT_READ_MAX;
+	}
+
+	k_mutex_lock(&frame_lock, K_FOREVER);
+
+	/* Refuse rather than silently serve the wrong frame: the buffer holds
+	 * exactly one, and a newer CAPTURE replaces it mid-pull. seq 0 never
+	 * matches, so "nothing captured yet" answers the same way. */
+	if (frame_vbuf == NULL || seq != frame_seq) {
+		k_mutex_unlock(&frame_lock);
+		return MGMT_ERR_ENOENT;
+	}
+
+	off = MIN(off, frame_vbuf->bytesused);
+	want = MIN(want, frame_vbuf->bytesused - off);
+	eof = (off + want) >= frame_vbuf->bytesused;
+	data.value = frame_vbuf->buffer + off;
+	data.len = want;
+
+	ok = zcbor_tstr_put_lit(zse, "seq") && zcbor_uint32_put(zse, seq) &&
+	     zcbor_tstr_put_lit(zse, "off") && zcbor_uint32_put(zse, off) &&
+	     zcbor_tstr_put_lit(zse, "data") && zcbor_bstr_encode(zse, &data) &&
+	     zcbor_tstr_put_lit(zse, "eof") && zcbor_bool_put(zse, eof);
+
+	k_mutex_unlock(&frame_lock);
+
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
+}
+
+static const struct mgmt_handler cam_mgmt_handlers[] = {
+	[CAM_MGMT_CMD_INFO] = {cam_h_info, NULL},
+	[CAM_MGMT_CMD_CAPTURE] = {NULL, cam_h_capture},
+	[CAM_MGMT_CMD_READ] = {cam_h_read, NULL},
+};
+
+static struct mgmt_group cam_mgmt_group = {
+	.mg_handlers = cam_mgmt_handlers,
+	.mg_handlers_count = ARRAY_SIZE(cam_mgmt_handlers),
+	.mg_group_id = CAM_MGMT_GROUP_ID,
+};
+
+static void cam_mgmt_register(void)
+{
+	mgmt_register_group(&cam_mgmt_group);
+}
+
+MCUMGR_HANDLER_DEFINE(cam_mgmt, cam_mgmt_register);

--- a/applications/data_collection/src/cam_mgmt.h
+++ b/applications/data_collection/src/cam_mgmt.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Richard Osterloh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef APP_CAM_MGMT_H_
+#define APP_CAM_MGMT_H_
+
+#include <zephyr/device.h>
+
+/**
+ * @brief Capture one frame into the buffer retained for the SMP camera group.
+ *
+ * Releases the previously retained frame, captures a new one and bumps the
+ * sequence number served by the CAPTURE/READ commands.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int cam_mgmt_capture(const struct device *cam);
+
+#endif /* APP_CAM_MGMT_H_ */

--- a/applications/data_collection/src/main.c
+++ b/applications/data_collection/src/main.c
@@ -8,15 +8,10 @@
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/net_event.h>
-#include <zephyr/drivers/video.h>
+
+#include "cam_mgmt.h"
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
-
-/* IMX219 2x2-binned full-FoV RAW10 frame. */
-#define CAPTURE_WIDTH  1640
-#define CAPTURE_HEIGHT 1232
-#define CAPTURE_FORMAT VIDEO_PIX_FMT_SBGGR10P
-#define CAPTURE_NBUFS  2
 
 static struct net_mgmt_event_callback ipv4_cb;
 
@@ -40,65 +35,6 @@ static void on_ipv4_addr_add(struct net_mgmt_event_callback *cb, uint64_t mgmt_e
 	}
 }
 
-static int capture_one_frame(const struct device *cam)
-{
-	struct video_format fmt = {
-		.type = VIDEO_BUF_TYPE_OUTPUT,
-		.pixelformat = CAPTURE_FORMAT,
-		.width = CAPTURE_WIDTH,
-		.height = CAPTURE_HEIGHT,
-	};
-	struct video_buffer *vbuf;
-	int ret;
-
-	ret = video_set_format(cam, &fmt);
-	if (ret < 0) {
-		LOG_ERR("Failed to set format (%d)", ret);
-		return ret;
-	}
-
-	ret = video_get_format(cam, &fmt);
-	if (ret < 0) {
-		return ret;
-	}
-	LOG_INF("Capturing %ux%u, pitch %u, %u bytes/frame", fmt.width, fmt.height, fmt.pitch,
-		fmt.pitch * fmt.height);
-
-	for (int i = 0; i < CAPTURE_NBUFS; i++) {
-		vbuf = video_buffer_aligned_alloc(fmt.pitch * fmt.height,
-						  CONFIG_VIDEO_BUFFER_POOL_ALIGN, K_NO_WAIT);
-		if (vbuf == NULL) {
-			LOG_ERR("Failed to allocate video buffer %d", i);
-			return -ENOMEM;
-		}
-		vbuf->type = VIDEO_BUF_TYPE_OUTPUT;
-		ret = video_enqueue(cam, vbuf);
-		if (ret < 0) {
-			LOG_ERR("Failed to enqueue buffer %d (%d)", i, ret);
-			return ret;
-		}
-	}
-
-	ret = video_stream_start(cam, VIDEO_BUF_TYPE_OUTPUT);
-	if (ret < 0) {
-		LOG_ERR("Failed to start stream (%d)", ret);
-		return ret;
-	}
-
-	ret = video_dequeue(cam, &vbuf, K_SECONDS(2));
-	if (ret < 0) {
-		LOG_ERR("Failed to dequeue frame (%d)", ret);
-		video_stream_stop(cam, VIDEO_BUF_TYPE_OUTPUT);
-		return ret;
-	}
-
-	LOG_INF("Frame captured: %u bytes, first pixels %02x %02x %02x %02x", vbuf->bytesused,
-		vbuf->buffer[0], vbuf->buffer[1], vbuf->buffer[2], vbuf->buffer[3]);
-
-	video_stream_stop(cam, VIDEO_BUF_TYPE_OUTPUT);
-	return 0;
-}
-
 int main(void)
 {
 	const struct device *cam = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
@@ -113,9 +49,12 @@ int main(void)
 		return 0;
 	}
 
-	if (capture_one_frame(cam) == 0) {
-		LOG_INF("Camera capture OK; use the `video` shell for further captures");
+#if defined(CONFIG_APP_CAM_MGMT)
+	if (cam_mgmt_capture(cam) == 0) {
+		LOG_INF("Camera capture OK; pull it with the SMP camera group (0x1000) or "
+			"capture again from the `video` shell");
 	}
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Adds a custom MCUmgr (SMP) management group so a host can drive the camera over the **same SMP/UDP transport the app already uses for OTA**, instead of only the boot-time capture and the interactive `video` shell.

Pattern lifted from [Protocentral/healthypi-move-fw](https://github.com/Protocentral/healthypi-move-fw), which serves its whole health-history API as a custom group (`0x1000`) rather than a bespoke BLE protocol — the transport, CBOR framing and off-the-shelf clients all come for free.

No new transport and no new sockets: the app already links `MCUMGR`, `ZCBOR`, `MCUMGR_TRANSPORT_UDP`, `GRP_OS` and `GRP_IMG`.

## Command set

Group `0x1000` (clear of `MGMT_GROUP_ID_PERUSER` = 64, which Zephyr's own groups count *down* from).

| cmd | name | op | request | response |
|---|---|---|---|---|
| 0 | INFO | read | — | `group` u32, `cam` tstr, `fmt` u32, `w`, `h`, `ready` bool |
| 1 | CAPTURE | write | — | `seq` u32, `size` u32, `w`, `h`, `fmt` |
| 2 | READ | read | `seq` u32, `off` u32, `len` u16 | `seq`, `off`, `data` bstr, `eof` bool |

- READ is cursor-paged; the client repeats with `off += len(data)` until `eof`. Chunks cap at 1024 B.
- READ and CAPTURE both return `MGMT_ERR_ENOENT` when the frame is gone (never captured, or replaced mid-pull) rather than silently serving the wrong one. `seq` starts at 1 so the decoder default of 0 never matches.
- `INFO`'s `fmt`/`w`/`h` are the **requested** planning values, not the negotiated ones; clients must size from `CAPTURE`'s `size`. Called out in the comment and README.

Wire contract is documented in a README section.

## Pre-existing bug fixed in passing

The original `capture_one_frame()` allocated `CAPTURE_NBUFS` buffers per call and **never released them**, and left the un-dequeued buffer stranded. It only ever ran once at boot, so nothing surfaced it — but a second call would have exhausted the pool (`CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=2`). The refactored version releases the retained frame first and drains what `video_stream_stop()` cancels.

## Concurrency and buffer ownership

The captured frame (~2.5 MB of PSRAM) stays checked out of the pool until the next CAPTURE and is served in place rather than copied. A `frame_lock` mutex guards it, because the boot capture runs on the main thread while the SMP thread can already be serving requests.

Two review fixes on top of the first pass, both reachable from the network:
- **Drain loop no longer aliases the retained frame.** It now uses a separate variable plus an identity check, so it is correct regardless of whether the OOT `video_esp32_csi.c` flush behaves like `subsys/video/stream.c`. Releasing that buffer would have served freed PSRAM to any client that asked.
- **NULL guard in the CAPTURE handler.** `cam_mgmt_capture()` drops the lock before returning, so a concurrent capture that released the frame and then failed could leave the handler dereferencing NULL.

## Verification

- `mise run agent-build data_collection` on `esp32p4_nano/esp32p4/hpcore` — **succeeds**, `CONFIG_APP_CAM_MGMT=y`, no new warnings.
- **Not runtime-verified** — no hardware in this session, and the logic is device-bound (real CSI capture). No SMP client has exercised these commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)